### PR TITLE
Add configurable attendee-facing badge types, with set prices

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -234,6 +234,9 @@ class Config(_Overridable):
         opts = []
         if self.ATTENDEE_BADGE_AVAILABLE:
             opts.append((self.ATTENDEE_BADGE, 'Full Weekend Pass (${})'.format(self.BADGE_PRICE)))
+        for badge_type in self.BADGE_TYPE_PRICES:
+            if badge_type not in opts:
+                opts.append((badge_type, '{} (${})'.format(self.BADGES[badge_type], self.BADGE_TYPE_PRICES[badge_type])))
         if self.ONE_DAYS_ENABLED:
             if self.PRESELL_ONE_DAYS:
                 day = max(sa.localized_now(), self.EPOCH)

--- a/uber/config.py
+++ b/uber/config.py
@@ -164,6 +164,9 @@ class Config(_Overridable):
         for reg_open, badge_type in [(self.BEFORE_GROUP_PREREG_TAKEDOWN, self.PSEUDO_GROUP_BADGE)]:
             if reg_open:
                 types.append(badge_type)
+        for badge_type in self.BADGE_TYPE_PRICES:
+            if badge_type not in types:
+                types.append(badge_type)
         return types
 
     @property
@@ -465,6 +468,13 @@ for _name, _section in _config['integer_enums'].items():
 c.BADGE_RANGES = {}
 for _badge_type, _range in _config['badge_ranges'].items():
     c.BADGE_RANGES[getattr(c, _badge_type.upper())] = _range
+
+c.BADGE_TYPE_PRICES = {}
+for _badge_type, _price in _config['badge_type_prices'].items():
+    try:
+        c.BADGE_TYPE_PRICES[getattr(c, _badge_type.upper())] = _price
+    except AttributeError:
+        pass
 
 c.make_enum('age_group', OrderedDict([(name, section['desc']) for name, section in _config['age_groups'].items()]))
 c.AGE_GROUP_CONFIGS = {}

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -372,6 +372,13 @@ eschaton = string(default="2016-01-26 18")
 __many__ = string
 
 
+[badge_type_prices]
+# Add badge types here to make them attendee-facing badges. They will be displayed
+# on the pre-reg form and may be purchased by attendees. These badge types will
+# function much like Attendee badges, although they cannot have price bumps.
+__many__ = integer
+
+
 [badge_prices]
 # These settings (but not in subsections) are also exported as global constants.
 
@@ -407,12 +414,6 @@ group_discount = integer(default=10)
 
 # Dealer badge prices always cost this amount and don't change over time.
 dealer_badge_price = integer(default=30)
-
-[badge_type_prices]
-# Add badge types here to make them attendee-facing badges. They will be displayed
-# on the pre-reg form and may be purchased by attendees. These badge types will
-# function much like Attendee badges, although they cannot have price bumps.
-__many__ = integer
 
 [[single_day]]
 # Set (capitalized) day names equal to their overriden prices in this section.

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -408,6 +408,12 @@ group_discount = integer(default=10)
 # Dealer badge prices always cost this amount and don't change over time.
 dealer_badge_price = integer(default=30)
 
+[badge_type_prices]
+# Add badge types here to make them attendee-facing badges. They will be displayed
+# on the pre-reg form and may be purchased by attendees. These badge types will
+# function much like Attendee badges, although they cannot have price bumps.
+__many__ = integer
+
 [[single_day]]
 # Set (capitalized) day names equal to their overriden prices in this section.
 # For example, you could say "Thursday = 20" to make Thursday single-day badges

--- a/uber/models.py
+++ b/uber/models.py
@@ -1331,6 +1331,8 @@ class Attendee(MagModel, TakesPaymentMixin):
             return c.get_oneday_price(registered)
         elif self.is_presold_oneday:
             return c.get_presold_oneday_price(self.badge_type)
+        if self.badge_type in c.BADGE_TYPE_PRICES:
+            return int(c.BADGE_TYPE_PRICES[self.badge_type])
         elif self.age_discount != 0:
             return max(0, c.get_attendee_price(registered) + self.age_discount)
         elif self.group and self.paid == c.PAID_BY_GROUP:

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -55,7 +55,6 @@
 
 <form method="post" action="form" class="form-horizontal" role="form">
 
-<input type="hidden" name="badge_type" value="{{ attendee.badge_type }}" />
 {% if edit_id %}
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -37,7 +37,7 @@
                 description: 'A single registration; you can register more before paying.',
                 onClick: function () {
                     $('.group_fields').addClass('hide');
-                    $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+                    if ($.field('badge_type').val() == '{{ c.PSEUDO_GROUP_BADGE }}') { $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}'); }
                     if ($.field('first_name')) {
                         $('#bold-field-message').insertBefore($.field('first_name').parents('.form-group'));
                     }
@@ -73,31 +73,52 @@
             options: [{
                 title: '{% if c.PAGE_PATH == "/preregistration/form" or c.PAGE_PATH == "/preregistration/dealer_registration" %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
-                extra: 0
+                extra: 0,
+                price: {{ c.BADGE_PRICE }}
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and c.SHIRT_AVAILABLE %}
             BADGE_TYPES.options.push({
                 title: 'Add a tshirt',
                 description: 'Add a {{ c.EVENT_NAME }} themed t-shirt to your registration.',
-                extra: {{ c.SHIRT_LEVEL }}
+                extra: {{ c.SHIRT_LEVEL }},
+                price: {{ c.BADGE_PRICE }}
             });
         {% endif %}
         {% if c.SUPPORTER_LEVEL in c.PREREG_DONATION_TIERS and c.SUPPORTER_AVAILABLE %}
             BADGE_TYPES.options.push({
                 title: 'Supporter',
                 description: 'Donate extra and get more swag with your registration.',
-                extra: {{ c.SUPPORTER_LEVEL }}
+                extra: {{ c.SUPPORTER_LEVEL }},
+                price: {{ c.BADGE_PRICE }}
             });
         {% endif %}
+        {% for badge_type in c.BADGE_TYPE_PRICES %}
+            {% if badge_type != c.ATTENDEE_BADGE %}
+            BADGE_TYPES.options.push({
+                title: '{{ c.BADGES[badge_type] }}',
+                description: 'Donate extra to get an upgraded badge with perks.',
+                extra: 0,
+                price: {{ c.BADGE_TYPE_PRICES[badge_type] }},
+                badge_type: '{{ badge_type }}',
+                onClick: function () {
+                    $('input[name="badge_type"]').val('{{ badge_type }}');
+                }
+            });
+            {% endif %}
+        {% endfor %}
+
+        BADGE_TYPES.options.sort(function(a, b){
+            return a.price > b.price;
+        });
 
         var togglePrices = function () {
-            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.PREREG_DONATION_DESCRIPTIONS %}($.val('badge_type') === {{ c.ATTENDEE_BADGE }}){% else %}false{% endif %};
+            var showTotalPrices = {% if c.PAGE_PATH == '/preregistration/form' and not c.PREREG_DONATION_DESCRIPTIONS %}($.val('badge_type') != {{ c.PSEUDO_DEALER_BADGE }}){% else %}false{% endif %};
             $.each(BADGE_TYPES.options, function (i, type) {
                 var $price = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price').empty();
                 var $price_notice = $(BADGE_TYPES.selector).slice(i, i + 1).find('.price_notice').empty();
                 if (showTotalPrices) {
-                    $price.append(': $').append(type.extra + {{ c.BADGE_PRICE }});
+                    $price.append(': $').append(type.extra + type.price);
                     {% for amount_extra, val in c.PREREG_DONATION_OPTS %}
                         if (type.extra == {{ amount_extra }} && type.extra >= {{ c.SUPPORTER_LEVEL }}) {
                             $price_notice.append('{{ price_notice("Supporter registration", c.SUPPORTER_DEADLINE, c.SUPPORTER_LEVEL) }}')
@@ -107,6 +128,8 @@
                     {% endfor %}
                 } else if (type.extra) {
                     $price.append(': +$').append(type.extra);
+                } else if (type.price) {
+                    $price.append(': $').append(type.price);
                 }
             });
             $.each(REG_TYPES.options, function (i, type) {
@@ -146,6 +169,8 @@
                 var target = 0;
                 $.each(BADGE_TYPES.options, function (i, badgeType) {
                     if (badgeType.extra && $.field('amount_extra') && badgeType.extra == $.val('amount_extra')) {
+                        target = i;
+                    } else if (badgeType.badge_type && badgeType.badge_type == $.val('badge_type')) {
                         target = i;
                     }
                 });

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -37,10 +37,13 @@
                 description: 'A single registration; you can register more before paying.',
                 onClick: function () {
                     $('.group_fields').addClass('hide');
-                    if ($.field('badge_type').val() == '{{ c.PSEUDO_GROUP_BADGE }}') { $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}'); }
+                    if ($.field('badge_type').val() == '{{ c.PSEUDO_GROUP_BADGE }}') {
+                        $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+                    }
                     if ($.field('first_name')) {
                         $('#bold-field-message').insertBefore($.field('first_name').parents('.form-group'));
                     }
+                    showOrHideBadgeTypes();
                     togglePrices();
                 }
             }]
@@ -58,6 +61,7 @@
                         $('.group_fields').removeClass('hide');
                         $('input[name="badge_type"]').val('{{ c.PSEUDO_GROUP_BADGE }}');
                         $('#bold-field-message').insertBefore($.field('name').parents('.form-group'));
+                        showOrHideBadgeTypes();
                         togglePrices();
                     {% else %}
                         setBadge(REG_TYPES, 0);
@@ -71,10 +75,13 @@
             row: '#badge-types',
             selector: '.badge-type-selector',
             options: [{
-                title: '{% if c.PAGE_PATH == "/preregistration/form" or c.PAGE_PATH == "/preregistration/dealer_registration" %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
+                title: '{% if c.PAGE_PATH == "/preregistration/form" or c.PAGE_PATH == "/preregistration/dealer_registration" or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
                 extra: 0,
-                price: {{ c.BADGE_PRICE }}
+                price: {{ c.BADGE_PRICE }},
+                onClick: function () {
+                    $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
+                }
             }]
         };
         {% if c.SHIRT_LEVEL in c.PREREG_DONATION_TIERS and c.SHIRT_AVAILABLE %}
@@ -93,6 +100,7 @@
                 price: {{ c.BADGE_PRICE }}
             });
         {% endif %}
+
         {% for badge_type in c.BADGE_TYPE_PRICES %}
             {% if badge_type != c.ATTENDEE_BADGE %}
             BADGE_TYPES.options.push({
@@ -146,6 +154,24 @@
                 }
             });
         };
+        var showOrHideBadgeTypes = function () {
+            // We use 'pseudo' badge types to create dealers and groups, which is antithetical to using attending-facing
+            // badge types for upgrades. We thus want to hide any badge buttons with a unique badge type if the attendee
+            // is a dealer or group leader.
+            if ($(BADGE_TYPES.row).size()) {
+                $.each(BADGE_TYPES.options, function (i, badgeType) {
+                    if (badgeType.badge_type && badgeType.badge_type != {{ c.ATTENDEE_BADGE }}) {
+                        var current_button = $(BADGE_TYPES.selector).slice(i, 1+i);
+                        current_button.toggle($.field('badge_type').val() != '{{ c.PSEUDO_GROUP_BADGE }}' && $.field('badge_type').val() != '{{ c.PSEUDO_DEALER_BADGE }}');
+                        // If an 'invalid' badge type is currently selected when the reg type is changed, reset to the
+                        // first in the list
+                        if (!current_button.is(":visible") && current_button.hasClass('active')) {
+                            setBadge(BADGE_TYPES, 0);
+                        }
+                    }
+                });
+            }
+        };
         var setBadge = function (types, index) {
             var type = types.options[index];
             $(types.selector)
@@ -180,6 +206,7 @@
             }
         };
         $(function () {
+            showOrHideBadgeTypes();
             if ($(BADGE_TYPES.row).size()) {
                 $.each([REG_TYPES, BADGE_TYPES], function (i, types) {
                     $.each(types.options, function (index, type) {

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -26,6 +26,7 @@
         {% endif %}
     };
     $(function () {
+        togglePrices();
         staffingClicked();
         if ($.field('staffing')) {
             {% if c.AT_THE_CON %} $.field('staffing').prop('disabled', true).prop('title', 'Please see Staffing Operations to change your volunteer status.'); {% endif %}
@@ -110,7 +111,7 @@
 {% endif %}
 
 {% if c.DONATIONS_ENABLED and c.PAGE_PATH != '/registration/form' %}
-    {% if c.PREREG_DONATION_OPTS.length > 1 or attendee.amount_extra %}
+    {% if c.PREREG_DONATION_OPTS and c.PREREG_DONATION_OPTS.length > 1 or attendee.amount_extra %}
         <script type="text/javascript">
             var donationChanged = function () {
                 setVisible('.affiliate-row', $.val('amount_extra') > 0);
@@ -517,6 +518,10 @@
     </div>
 </div>
 
+{% if c.PAGE_PATH != '/registration/form' %}
+<input type="hidden" name="badge_type" value="{{ attendee.badge_type }}" />
+{% endif %}
+
 {% include "regextra.html" %}
 
 <script type="text/javascript">
@@ -524,6 +529,9 @@
         // This removes any badge levels lower than the attendee has purchased already
         if (window.BADGE_TYPES) {
             while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {
+                BADGE_TYPES.options.splice(0, 1);
+            }
+            while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].price && BADGE_TYPES.options[0].price < {{ c.BADGE_TYPE_PRICES[attendee.badge_type] }}) {
                 BADGE_TYPES.options.splice(0, 1);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/1. Fixes https://github.com/MidwestFurryFandom/rams/issues/2. Fixes https://github.com/MidwestFurryFandom/rams/issues/3. Fixes https://github.com/MidwestFurryFandom/rams/issues/4. Does all this by adding and integrating a new config option badge types called badge_type_prices. Adding badge types to this option puts them on the pre-reg and confirmation pages as attendee-facing badge types. Unlike the attendee badge, however, their price is fixed and cannot change.