### PR TITLE
Allow attendees to repurchase refunded badges

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -122,7 +122,7 @@ transferable_badge_types = string_list(default=list('attendee_badge'))
 # date someone preregistered and their badge type, but we need to reset most other
 # things.  This is a list of what needs to be reset, which is configurable so that
 # other events with custom fields can add fields.
-untransferable_attrs = string_list(default=list('first_name','last_name','email','birthdate','zip_code','international','ec_name','ec_phone','cellphone','interests','age_group','staffing','requested_depts'))
+untransferable_attrs = string_list(default=list('first_name','last_name','legal_name','email','birthdate','zip_code','international','ec_name','ec_phone','cellphone','interests','age_group','staffing','requested_depts'))
 
 # Some departments don't use our shift system, so we don't want to email
 # volunteers in those departments asking them to sign up for shifts.  Make this

--- a/uber/models.py
+++ b/uber/models.py
@@ -719,6 +719,9 @@ class Session(SessionManager):
         def valid_attendees(self):
             return self.query(Attendee).filter(Attendee.badge_status != c.INVALID_STATUS)
 
+        def attendees_with_badges(self):
+            return self.query(Attendee).filter(not_(Attendee.badge_status.in_([c.INVALID_STATUS, c.REFUNDED_STATUS, c.DEFERRED_STATUS])))
+
         def all_attendees(self, only_staffing=False):
             """
             Returns a Query of Attendees with efficient loading for groups and

--- a/uber/templates/preregistration/repurchase.html
+++ b/uber/templates/preregistration/repurchase.html
@@ -1,0 +1,21 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Repurchase Your Badge{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+<div class="masthead"></div>
+
+<h2>Refunded Badge</h2>
+
+<div class="form-group">
+    According to our records, your badge has been refunded. You may repurchase your badge at the current price of
+    ${{ c.BADGE_PRICE }} for an Attendee badge. We will pre-fill your details into the pre-registration form.
+
+    <form method="post" action="repurchase" class="form-horizontal">
+        {{ csrf_token() }}
+        <input type="hidden" name="id" value="{{ id }}" />
+        <button type="submit" class="btn btn-primary" value="Repurchase">Yes, I want to repurchase my badge</button>
+    </form>
+</div>
+
+{% endblock %}}

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -95,7 +95,7 @@
     var sameLegalNameChecked = function () {
         if ($("#same_legal_name").prop('checked')) {
             $.field('legal_name').prop('readonly', true).val('').attr('required', false);
-        } else {
+        } else if ($("#same_legal_name").length) {
             $.field('legal_name').prop('readonly', false).attr('required', true);
         }
     };
@@ -582,7 +582,7 @@
             while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {
                 BADGE_TYPES.options.splice(0, 1);
             }
-            while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].price && BADGE_TYPES.options[0].price < {{ c.BADGE_TYPE_PRICES[attendee.badge_type] }}) {
+            while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].price && BADGE_TYPES.options[0].price < {{ c.BADGE_TYPE_PRICES[attendee.badge_type]|default(c.BADGE_PRICE) }}) {
                 BADGE_TYPES.options.splice(0, 1);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/13. When an attendee visits the confirmation page of a Refunded badge, they will be given the option to buy a new badge. Their information is transferred over. Also fixes a couple JS bugs, and stops the system detecting Refunded and Deferred badges as duplicates (because those badges are not valid for checking in).