### PR TITLE
Add an option to disable the 'slow loading' page

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -258,6 +258,11 @@ email_re            = string(default="^[a-zA-Z0-9_\-+.]+@[a-zA-Z0-9_\-+.]+(\.[a-
 # implemented a feature that replaces "Fest" with "Con" just for them.
 jerks = string_list(default=list('Nick Marinelli', 'Nicholas Marinelli', 'Matt Reid', 'Matthew Reid'))
 
+# Before the event, we use a "slow loading" page to help make sure attendees with
+# obnoxiously old hardware don't try to refresh the pages. However, attendees who
+# rapidly click between page loads may end up redirecting themselves to the explanation
+# we provide, causing confusion. Turn this off to disable the slow loading page.
+slow_load_check = boolean(default=True)
 
 [secret]
 # Config options in this section are accessible as normal through the global

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -145,7 +145,7 @@
     {% block head_additional %}{% endblock %}
 </head>
 <body>
-    {% if c.PRE_CON %}
+    {% if c.PRE_CON and c.SLOW_LOAD_CHECK %}
         <div class="loader"><a class="loader_link" href="../static_views/slow_load.html" target="_blank"></a></div>
     {% endif %}
     {% block top_of_body_additional %}


### PR DESCRIPTION
Attempts to fix what I believe is the cause of https://github.com/MidwestFurryFandom/rams/issues/155 by allowing events to disable the "Slow Loading" page. The config option is set to true by default to avoid surprising events that depend on this page being in use.