### PR TITLE
Allow for promo codes without a discount

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -958,6 +958,7 @@ merch_items = force_list(default=list())
 [integer_enums]
 shirt_level     = integer(default=20)
 supporter_level = integer(default=60)
+season_level = integer(default=100)
 __many__ = integer
 
 

--- a/uber/models/promo_code.py
+++ b/uber/models/promo_code.py
@@ -237,7 +237,9 @@ class PromoCode(MagModel):
 
     @property
     def discount_str(self):
-        if not self.discount:
+        if self.discount_type == self._FIXED_DISCOUNT and self.discount == 0:
+            return 'No discount'
+        elif not self.discount:
             return 'Free badge'
 
         if self.discount_type == self._FIXED_DISCOUNT:
@@ -328,7 +330,7 @@ class PromoCode(MagModel):
             self.uses_allowed = None
 
         # If 'discount' is empty, then this is a full discount, free badge
-        if not self.discount:
+        if self.discount == '':
             self.discount = None
 
         self.code = self.code.strip() if self.code else ''


### PR DESCRIPTION
Even if a promo code gave a badge no discount, it would display as a "free badge." Also fixes a 500 error caused by missing config.