### PR TITLE
Stop deleting declined dealers and add cancellation option

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -1104,6 +1104,8 @@ vegan      = string(default="Vegan")
 unapproved = string(default="Pending Approval")
 waitlisted = string(default="Waitlisted")
 approved   = string(default="Approved")
+declined   = string(default="Declined")
+cancelled  = string(default="Cancelled")
 
 [[night]]
 monday    = string(default="Monday")

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -168,6 +168,12 @@ def group_money(group):
         return "What you entered for Amount Refunded ({}) wasn't even a number".format(group.amount_refunded)
 
 
+@validation.Group
+def no_edit_post_approval(group):
+    if group.status == c.APPROVED:
+        return "You cannot change your dealer application after approval."
+
+
 def _invalid_phone_number(s):
     try:
         # parse input as a US number, unless a leading + is provided,

--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -169,7 +169,7 @@ def decline_and_convert_dealer_groups():
         for group in groups:
             print('{}: {}'.format(
                 group.name,
-                _decline_and_convert_dealer_group(session, group, False)))
+                _decline_and_convert_dealer_group(session, group)))
 
 
 @entry_point

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -39,12 +39,13 @@ def _is_dealer_convertible(attendee):
     #     and c.DEALER_RIBBON in attendee.ribbon_ints
 
 
-def _decline_and_convert_dealer_group(session, group, delete_when_able=False):
+def _decline_and_convert_dealer_group(session, group, status=c.DECLINED):
     """
     Deletes the waitlisted dealer group and converts all of the group members
     to the appropriate badge type. Unassigned, unpaid badges will be deleted.
     """
     admin_note = 'Converted badge from waitlisted dealer group "{}".'.format(group.name)
+    group.status = status
 
     if not group.is_unpaid:
         group.tables = 0
@@ -57,26 +58,27 @@ def _decline_and_convert_dealer_group(session, group, delete_when_able=False):
     emails_failed = 0
     emails_sent = 0
     badges_converted = 0
-    badges_deleted = 0
 
-    group.leader = None
     for attendee in list(group.attendees):
-        if (delete_when_able or attendee.is_unassigned) and _is_attendee_disentangled(attendee):
-            session.delete(attendee)
-            badges_deleted += 1
+        if _is_dealer_convertible(attendee):
+            attendee.badge_status = c.INVALID_STATUS
 
-        else:
-            if _is_dealer_convertible(attendee):
-                attendee.badge_status = c.NEW_STATUS
-                attendee.overridden_price = attendee.new_badge_cost
+            if not attendee.is_unassigned:
+                new_attendee = Attendee()
+                for attr in c.UNTRANSFERABLE_ATTRS:
+                    setattr(new_attendee, attr, getattr(attendee, attr))
+                new_attendee.overridden_price = attendee.overridden_price
+                new_attendee.base_badge_price = attendee.base_badge_price
+                new_attendee.append_admin_note(admin_note)
+                session.add(new_attendee)
 
                 try:
                     send_email.delay(
-                        c.REGDESK_EMAIL,
-                        attendee.email,
+                        c.MARKETPLACE_EMAIL,
+                        new_attendee.email,
                         'Do you still want to come to {}?'.format(c.EVENT_NAME),
                         render('emails/dealers/badge_converted.html', {
-                            'attendee': attendee,
+                            'attendee': new_attendee,
                             'group': group}, encoding=None),
                         format='html',
                         model=attendee.to_dict('id'))
@@ -84,22 +86,18 @@ def _decline_and_convert_dealer_group(session, group, delete_when_able=False):
                 except Exception:
                     emails_failed += 1
 
-            badges_converted += 1
-
+                badges_converted += 1
+        else:
             if attendee.paid not in [c.HAS_PAID, c.NEED_NOT_PAY]:
                 attendee.paid = c.NOT_PAID
 
             attendee.append_admin_note(admin_note)
             attendee.ribbon = remove_opt(attendee.ribbon_ints, c.DEALER_RIBBON)
-            group.attendees.remove(attendee)
-
-    session.delete(group)
 
     for count, template in [
             (badges_converted, '{} badge{} converted'),
             (emails_sent, '{} email{} sent'),
-            (emails_failed, '{} email{} failed to send'),
-            (badges_deleted, '{} badge{} deleted')]:
+            (emails_failed, '{} email{} failed to send')]:
 
         if count > 0:
             message.append(template.format(count, pluralize(count)))
@@ -112,7 +110,7 @@ class Root:
     def index(self, session, message='', order='name', show='all'):
         which = {
             'all':    [],
-            'tables': [Group.tables > 0],
+            'tables': [Group.tables > 0, Group.status != c.DECLINED],
             'groups': [Group.tables == 0]
         }[show]
         # TODO: think about using a SQLAlchemy column property for .badges and then just use .order()
@@ -127,9 +125,9 @@ class Root:
             'order':             Order(order),
             'total_groups':      len(groups),
             'total_badges':      sum(g.badges for g in groups),
-            'tabled_badges':     sum(g.badges for g in groups if g.tables),
+            'tabled_badges':     sum(g.badges for g in groups if g.tables and g.status != c.DECLINED),
             'untabled_badges':   sum(g.badges for g in groups if not g.tables),
-            'tabled_groups':     len([g for g in groups if g.tables]),
+            'tabled_groups':     len([g for g in groups if g.tables and g.status != c.DECLINED]),
             'untabled_groups':   len([g for g in groups if not g.tables]),
             'tables':            sum(g.tables for g in groups),
             'unapproved_tables': sum(g.tables for g in groups if g.status == c.UNAPPROVED),
@@ -206,14 +204,14 @@ class Root:
             message = ''
             if decline_and_convert:
                 for group in groups:
-                    _decline_and_convert_dealer_group(session, group, False)
+                    _decline_and_convert_dealer_group(session, group)
                 message = 'All waitlisted dealers have been declined and converted to regular attendee badges'
             raise HTTPRedirect('index?order=name&show=tables&message={}', message)
 
         return {'groups': query.all()}
 
     @ajax
-    def unapprove(self, session, id, action, email, convert=None, message=''):
+    def unapprove(self, session, id, action, email, message=''):
         assert action in ['waitlisted', 'declined']
         group = session.group(id)
         subject = 'Your {} Dealer registration has been {}'.format(c.EVENT_NAME, action)
@@ -228,10 +226,17 @@ class Root:
         if action == 'waitlisted':
             group.status = c.WAITLISTED
         else:
-            message = _decline_and_convert_dealer_group(session, group, not convert)
+            message = _decline_and_convert_dealer_group(session, group)
         session.commit()
         return {'success': True,
                 'message': message}
+
+    def cancel_dealer(self, session, id):
+        group = session.group(id)
+        _decline_and_convert_dealer_group(session, group, c.CANCELLED)
+        message = "Sorry you couldn't make it! Group members have been emailed confirmations for individual badges."
+
+        raise HTTPRedirect('../preregistration/group_members?id={}&message={}', group.id, message)
 
     @csrf_protected
     def delete(self, session, id, confirmed=None):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -419,7 +419,7 @@ class Root:
     def group_members(self, session, id, message='', **params):
         group = session.group(id)
         charge = Charge(group)
-        if group.status != c.APPROVED and 'name' in params:
+        if cherrypy.request.method == 'POST':
             # Both the Attendee class and Group class have identically named
             # address fields. In order to distinguish the two sets of address
             # fields in the params, the Group fields are prefixed with "group_"

--- a/uber/site_sections/summary.py
+++ b/uber/site_sections/summary.py
@@ -198,6 +198,7 @@ class Root:
     def dealer_table_info(self, out, session):
         out.writerow([
             'Business Name',
+            'Dealer Name',
             'Description',
             'URL',
             'Point of Contact',
@@ -217,8 +218,10 @@ class Root:
         dealer_groups = session.query(Group).filter(Group.tables > 0).all()
         for group in dealer_groups:
             if group.approved and group.is_dealer:
+                full_name = group.leader.full_name if group.leader else ''
                 out.writerow([
                     group.name,
+                    full_name,
                     group.description,
                     group.website,
                     group.leader.legal_name or group.leader.full_name,

--- a/uber/templates/emails/dealers/badge_converted.html
+++ b/uber/templates/emails/dealers/badge_converted.html
@@ -4,11 +4,11 @@
 
 {{ attendee.first_name }},
 
-<br/><br/>Although your group ({{ group.name}}) was not taken off the waitlist, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
+<br/><br/>Although your group ({{ group.name}}) {{ 'cancelled their dealer application' if group.status == c.CANCELLED else 'was not taken off the waitlist' }}, we think you may still want to come and enjoy all that {{ c.EVENT_NAME }} has to offer!
 Therefore, we have reserved a badge for you{% if c.PRICE_BUMPS and attendee.badge_cost < c.BADGE_PRICE %} at the price of registration when you first applied{% endif %}.
 Badges went to anyone in your group who had a valid email on the badge, and any unassigned badges were dropped.
 
-<br/><br/>PLease note: You are choosing to accept or decline an ATTENDEE badge at the price it would have been had you bought it instead of applying to be a dealer. 
+<br/><br/>Please note: You are choosing to accept or decline an ATTENDEE badge at the price it would have been had you bought it instead of applying to be a dealer.
   <strong>You were not accepted as a dealer, and will not have space in the Marketplace.</strong>
 
 <br/><br/>Please go ahead and confirm or decline <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">your registration</a>. We hope to see you this year!

--- a/uber/templates/emails/dealers/payment_notification.txt
+++ b/uber/templates/emails/dealers/payment_notification.txt
@@ -1,2 +1,2 @@
-"{{ group.name }}" has just paid for their Dealer registration.
+"{{ group.name }}" has just paid ${{ group.amount_paid }} for their Dealer registration.
 {{ c.URL_BASE }}/groups/form?id={{ group.id }}

--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -84,6 +84,7 @@
         <label for="categories" class="col-sm-3 control-label">What kinds of things do you sell?</label>
         <div class="col-sm-9">
             {{ macros.checkgroup(group, 'categories') }}
+            <input type="hidden" name="categories" value="{{ group.categories }}" disabled />
         </div>
         <div class="clearfix"></div>
         <div class="col-sm-6 col-sm-offset-3">

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -175,28 +175,18 @@
     <div class="form-group">
         <label class="col-sm-3 control-label">Status</label>
         <div id="status" class="col-sm-6">
-            {% if new_dealer %}
                 <select name="status">
-                    <option value="{{ c.APPROVED }}">Approved</option>
-                    <option value="{{ c.UNAPPROVED }}">Unapproved</option>
-                    <option value="{{ c.WAITLISTED }}">Waitlisted</option>
-                </select>
-            {% else %}
-                {{ group.status_label }} <br/>
-                {% if group.status != c.APPROVED %}
-                    <input type="checkbox" name="status" value="{{ c.APPROVED }}" /> Approved
-                    <a href="#" onClick="$('#setstatus').toggle(); return false;">Waitlist or Reject</a> <br/>
-                    <div id="setstatus" style="display:none">
-                        Enter an email message to be sent along with the notification: <br/>
-                        (The email subject will be "Your {{ c.EVENT_NAME }} Dealer registration has been [waitlisted | declined]")
-                        <textarea name="email", rows="5" cols="50"></textarea> <br/>
-                        <button onClick="unapprove('waitlisted'); return false;">Waitlist</button>
-                        <button onClick="unapprove('declined'); return false;">Reject</button>
-                        <br/><button onClick="unapprove('declined', true); return false;">Reject and Convert Badges</button>
-                        <p class="help-block">(Allows rejected dealers to register at the price they would have paid when they applied.)</p>
-                    </div>
-                {% endif %}
-            {% endif %}
+                    {{ options(c.DEALER_STATUS_OPTS,group.status) }}
+                </select><br/>
+                <a href="#" onClick="$('#setstatus').toggle(); return false;">Waitlist or Decline (with Email)</a> <br/>
+                <div id="setstatus" style="display:none">
+                    Enter an email message to be sent along with the notification: <br/>
+                    (The email subject will be "Your {{ c.EVENT_NAME }} Dealer registration has been [waitlisted | declined]")
+                    <textarea name="email" rows="5" cols="50"></textarea> <br/>
+                    <button onClick="unapprove('waitlisted'); return false;">Waitlist</button>
+                    <br/><button onClick="unapprove('declined'); return false;">Reject and Convert Badges</button>
+                    <p class="help-block">(Allows rejected dealers to register at the price they would have paid when they applied.)</p>
+                </div>
         </div>
     </div>
 

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -379,6 +379,13 @@
 
           $('#region{{ suffix }}').val('{{ model[region_attr] }}');
           regionChange{{ suffix }}();
+          {% if model.status in [c.APPROVED, c.CANCELLED, c.DECLINED] and not admin_area %}
+        $(function() {
+            $("[name='group_region']").prop("disabled", false);
+            $("select[name='group_region']").prop("disabled", true);
+            $("[placeholder='Country']").prop("readonly", true);
+        });
+      {% endif %}
       });
   </script>
 
@@ -410,6 +417,7 @@
   <div class="form-group address_details{{ suffix }}">
     <label for="region{{ suffix }}" class="col-sm-3 control-label">State/Region</label>
     <div class="col-sm-6">
+      <input type="hidden" name="{{ name_prefix }}region" value="{{ model[region_attr] }}" id="hidden_region{{ suffix }}" disabled />
       <input type="text" name="{{ name_prefix }}region" id="region{{ suffix }}" class="form-control" placeholder="State/Province" value="{{ model[region_attr] }}" autocomplete="address-level1" {% if is_required %}required="required"{% endif %}/>
     </div>
   </div>

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -30,10 +30,36 @@
                 }
             });
         })
+
+        $("form[action='../groups/cancel_dealer']").submit(function(event){
+            var formToSubmit = this;
+            event.preventDefault();
+            bootbox.confirm({
+                message: "This will permanently cancel this application. All registered badges in the group will be converted to individual badges. Are you sure?",
+                buttons: {
+                    confirm: {
+                        label: 'Cancel Application',
+                        className: 'btn-danger'
+                    },
+                    cancel: {
+                        label: 'Nevermind',
+                        className: 'btn-default'
+                    }
+                },
+                callback: function (result) {
+                    if(result) {
+                        formToSubmit.submit();
+                    }
+                }
+            });
+        })
     });
-    {% if group.status == c.APPROVED %}
+    {% if group.status in [c.APPROVED, c.CANCELLED, c.DECLINED] %}
         $(function() {
-            $("form[action='group_members'] :input").attr("disabled", true).prop('title','You cannot edit your information after you have been approved.')
+            $("form[action='group_members'] :input").prop("readonly", true).prop('title','You cannot edit your information after you have {{ "cancelled" if group.status == c.CANCELLED else "been "~group.status_label }}');
+            $("form[action='group_members'] :submit, form[action='../groups/cancel_dealer'] :submit").prop("disabled", true);
+            $("[name='categories']").prop("disabled", false);
+            $("[name='categories']:checkbox, [name='group_country']").prop("disabled", true);
         });
     {% endif %}
 </script>
@@ -42,22 +68,40 @@
 <div class="panel panel-default">
   <div class="panel-body">
     {% if group.is_dealer %}
+    {% if group.status == c.APPROVED %}
+      <div class="alert alert-success">
+        Congratulations, your dealer application has been <strong>approved</strong>!
+          {% if group.amount_unpaid %}
+              {{ stripe_form('process_group_payment',charge) }}
+          {% endif %}
+        {% elif group.status == c.CANCELLED %}
+      <div class="alert alert-info">
+        You have <strong>cancelled</strong> your dealer application. If this was a mistake, please contact us at
+        <a href="mailto:{{ c.MARKETPLACE_EMAIL }}">{{ c.MARKETPLACE_EMAIL }}</a>.
+        {% else %}
+      <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }}">
+        Your dealer application {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.
+        {% endif %}
+      </div>
       <h2>"{{ group.name }}" Information</h2>
       <form method="post" action="group_members" class="form-horizontal" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />
         {% include "groupform.html" %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
+        <button type="submit" class="btn btn-danger" value="Cancel Dealer Application" form="cancel_dealer">Cancel Application</button>
       </form>
+        <form method="post" id="cancel_dealer" action="../groups/cancel_dealer" class="form-horizontal" role="form">
+          <input type="hidden" name="id" value="{{ group.id }}" />
+        </form>
     {% endif%}
 
+{% if group.status not in [c.CANCELLED, c.DECLINED] %}
 <h2> Members of "{{ group.name }}" </h2>
 
-{% if group.amount_unpaid and group.status != c.WAITLISTED %}
-    {% if not group.is_dealer or group.status != c.UNAPPROVED %}
-        <div style="text-align:center">
-            {{ stripe_form('process_group_payment',charge) }}
-        </div>
-    {% endif %}
+{% if group.amount_unpaid and not group.is_dealer %}
+    <div style="text-align:center">
+        {{ stripe_form('process_group_payment',charge) }}
+    </div>
 {% endif %}
 
 <div style="margin:15px">
@@ -169,7 +213,7 @@
             });
         {% endif %}
     </script>
-
+{% endif %}
 {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Adds two new statuses for groups -- Cancelled and Declined. Also upgrades the dealer confirmation page to tell them their app's status. When a dealer cancels their app all badges will automatically get converted to attendee badges.