### PR TITLE
Add #moretables back to group form template

### DIFF
--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -65,7 +65,7 @@
                 </select>
             </div>
             <div class="col-sm-offset-3 col-sm-9" id="table_prices">{{ table_prices() }}</div>
-            <p class="col-sm-9 col-sm-offset-3 help-block"><i>You may contact us via <a href='{{ c.CONTACT_URL }}'>{{ c.CONTACT_URL }}</a> to request more than {{ c.MAX_TABLES }} tables.</i></p>
+            <p class="col-sm-9 col-sm-offset-3 help-block" id="moretables"><i>You may contact us via <a href='{{ c.CONTACT_URL }}'>{{ c.CONTACT_URL }}</a> to request more than {{ c.MAX_TABLES }} tables.</i></p>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
mff-rams-plugin relies on this ID existing in order to hide this text. It was likely removed by accident when we merged from MAGFest, so we're adding it back.