### PR TITLE
Update group member wording

### DIFF
--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -106,8 +106,7 @@
 
 <div style="margin:15px">
     {% if group.unregistered_badges and group.tables %}
-        Some of your Dealer Assistant badges are not yet assigned to a specific person. Please assign these badges
-        between now (using the links below) and the close of preregistration; any badges unclaimed at that time will be
+        Some of your Dealer Assistant badges are not yet assigned to a specific person. Using the links below, please assign these badges before the close of preregistration; any badges unclaimed at that time will be
         invalid. You may also distribute each of the registration links below to the individual members of your group,
         which will allow them to fill in their own information as well as purchase any upgrades on their own.
         <br/> <br/>


### PR DESCRIPTION
Wording on instructions for group members was awkward. Now it is less so.
fixes #245 