### PR TITLE
Add ability to automatically filter any DataTable column

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -273,14 +273,48 @@
                 });
             };
 
-            $('.datatable').dataTable({
-                aLengthMenu: [
-                    [25, 50, 100, 200, -1],
-                    [25, 50, 100, 200, 'All']
-                ],
-                stateSave: true,
-                drawCallback: createDateTextEntries
-            });
+                $('.datatable').each(function() {
+                    var table = $(this).DataTable({
+                        aLengthMenu: [
+                            [25, 50, 100, 200, -1],
+                            [25, 50, 100, 200, 'All']
+                        ],
+                        stateSave: true,
+                        drawCallback: createDateTextEntries
+                    });
+
+                    table.columns().flatten().each( function ( colIdx ) {
+                        var header_name = $(table.column(colIdx).header()).text();
+
+                        // Is there a filter set up for this?
+                        var filter_span = $('#' + header_name.toLowerCase() + '_filter');
+
+                        if($(filter_span).length) {
+                        // Create the select list and search operation
+                        var select = $('<select><option label="(No Filter)"></option> </select>')
+                            .appendTo(
+                                filter_span
+                            )
+                            .on( 'change', function () {
+                                table
+                                    .column( colIdx )
+                                    .search( $(this).val() )
+                                    .draw();
+                            } );
+
+                        // Get the search data for the first column and add to the select list
+                        table
+                            .column( colIdx )
+                            .cache( 'search' )
+                            .sort()
+                            .unique()
+                            .each( function ( d ) {
+                                select.append( $('<option value="'+d+'">'+d+'</option>') );
+                            } );
+                        }
+                    } );
+                });
+
             createDateTextEntries();
 
             $('.geolocator').geocomplete({


### PR DESCRIPTION
This adds the ability to generate filters for any datatable-enabled column on any page by simply adding a span with the ID of "[lowercase table heading]_filter" to the page. The code in base.html will then generate a dropdown using the data in that column. The end result is a dynamic list of unique options to filter the table by.

Uses a modified version of https://datatables.net/manual/api#Example---column-filter