### PR TITLE
Removed ref to China from Taiwan

### DIFF
--- a/uber/static/deps/selectToAutocomplete/index.html
+++ b/uber/static/deps/selectToAutocomplete/index.html
@@ -269,7 +269,7 @@
       <option value="Sweden" data-alternative-spellings="SE Sverige" data-relevancy-booster="1.5">Sweden</option>
       <option value="Switzerland" data-alternative-spellings="CH Swiss Confederation Schweiz Suisse Svizzera Svizra" data-relevancy-booster="1.5">Switzerland</option>
       <option value="Syrian Arab Republic" data-alternative-spellings="SY Syria سورية">Syrian Arab Republic</option>
-      <option value="Taiwan, Province of China" data-alternative-spellings="TW 台灣 臺灣">Taiwan, Province of China</option>
+      <option value="Taiwan" data-alternative-spellings="TW 台灣">Taiwan</option>
       <option value="Tajikistan" data-alternative-spellings="TJ Тоҷикистон Toçikiston">Tajikistan</option>
       <option value="Tanzania, United Republic of" data-alternative-spellings="TZ">Tanzania, United Republic of</option>
       <option value="Thailand" data-alternative-spellings="TH ประเทศไทย Prathet Thai">Thailand</option>


### PR DESCRIPTION
fixes #260 

Confession: Best-guess on the characters based on some wikipedia reading. Pretty sure it says "Taiwan" now, but it might not say enough. Hard to tell. Ask Kofu.