### PR TITLE
Allow group leaders to drop non-transferable group members

### DIFF
--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -139,7 +139,7 @@
                 {% endif %}
             </td>
             <td>
-                {% if attendee != group.leader and not attendee.amount_extra and attendee.is_transferable %}
+                {% if attendee.can_abandon_badge %}
                   <form method="post" action="unset_group_member">
                     {{ csrf_token() }}
                     <input type="hidden" name="id" value="{{ attendee.id }}" />


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/244. For some reason we were using `is_transferable` as a proxy for telling if the group leader can drop someone's badge. We already have `can_abandon_badge` to see if someone can remove their own badge, so now we just use that.