### PR TITLE
Add support for an alternate payment page

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -342,7 +342,7 @@ def address(attendee):
 @validation.Attendee
 @ignore_unassigned_and_placeholders
 def zip_code(attendee):
-    if not attendee.international and not c.AT_OR_POST_CON:
+    if not attendee.international and not c.AT_OR_POST_CON and attendee.country == 'United States':
         if _invalid_zip_code(attendee.zip_code):
             return 'Enter a valid zip code'
 

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1018,6 +1018,11 @@ class Attendee(MagModel, TakesPaymentMixin):
         return (' with ' if stuff else '') + readable_join(stuff)
 
     @property
+    def payment_page(self):
+        # Some plugins need to redirect attendees to custom payment pages under certain circumstances
+        return 'attendee_donation_form?id={}'.format(self.id)
+
+    @property
     def multiply_assigned(self):
         return len(self.dept_memberships) > 1
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -713,7 +713,7 @@ class Root:
                 else:
                     raise HTTPRedirect(page + 'message=' + message)
 
-        elif attendee.amount_unpaid and attendee.zip_code and not undoing_extra:
+        elif attendee.amount_unpaid and attendee.zip_code and not undoing_extra and cherrypy.request.method == 'POST':
             # Don't skip to payment until the form is filled out
             raise HTTPRedirect('attendee_donation_form?id={}&message={}', attendee.id, message)
 
@@ -746,6 +746,8 @@ class Root:
         attendee = session.attendee(id)
         if attendee.amount_unpaid <= 0:
             raise HTTPRedirect('confirm?id={}', id)
+        if 'attendee_donation_form' not in attendee.payment_page:
+            raise HTTPRedirect(attendee.payment_page)
 
         return {
             'message': message,

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -36,7 +36,7 @@
 
       {% block form_top %}{% endblock %}
 
-      {% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' %}
+      {% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' and 'attendee_donation_form' in attendee.payment_page %}
         <br/>
         <div class="form-group">
           <div class="col-sm-9 col-sm-offset-3 warning">


### PR DESCRIPTION
Our art show app needs to redirect people to the art show app page when they have an unpaid app. This PR adds a variable into the main system so we can change it in the plugin.