### PR TITLE
Show dealer fields and support free dealers in certain circumstances

### DIFF
--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -119,7 +119,8 @@ class Group(MagModel, TakesPaymentMixin):
             self.tables
             and self.tables != '0'
             and self.tables != '0.0'
-            and (not self.registered or self.amount_paid or self.cost))
+            and (not self.registered or self.amount_paid or self.cost
+                 or self.status != c.UNAPPROVED))
 
     @is_dealer.expression
     def is_dealer(cls):

--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -153,12 +153,14 @@ class Root:
                         leader = group.leader = group.attendees[0]
                         leader.first_name, leader.last_name, leader.email = first_name, last_name, email
                         leader.placeholder = True
+                        session.commit() # Get the most up-to-date status
                         if group.status == c.APPROVED:
                             if group.amount_unpaid:
                                 raise HTTPRedirect('../preregistration/group_members?id={}', group.id)
                             else:
+                                status_msg = ", approved, and marked as paid" if group.cost else " and approved"
                                 raise HTTPRedirect(
-                                    'index?message={}', group.name + ' has been uploaded, approved, and marked as paid')
+                                    'index?message={}{}', group.name + ' has been uploaded', status_msg)
                         else:
                             raise HTTPRedirect(
                                 'index?message={}', group.name + ' is uploaded and ' + group.status_label)

--- a/uber/templates/groups/form.html
+++ b/uber/templates/groups/form.html
@@ -162,7 +162,7 @@
     </div>
 </div>
 
-{% if new_dealer or group.is_dealer %}
+{% if new_dealer or group.is_dealer or group.categories %}
     {% if group.leader %}
         <div class="form-group">
             <label class="col-sm-3 control-label">Phone Number</label>


### PR DESCRIPTION
This does two things: ALWAYS show dealer fields if a group has categories, and count a group as a dealer if they have any status besides Unapproved. This should help fix https://github.com/MidwestFurryFandom/rams/issues/259 without breaking everything unexpectedly.