### PR TITLE
Add 'post_dealer' URL to track in-progress dealer applications

### DIFF
--- a/uber/decorators.py
+++ b/uber/decorators.py
@@ -70,7 +70,8 @@ def redirect_if_at_con_to_kiosk(func):
 def check_if_can_reg(func):
     @wraps(func)
     def with_check(*args, **kwargs):
-        is_dealer_get = c.HTTP_METHOD == 'GET' and c.PAGE_PATH == '/preregistration/dealer_registration'
+        is_dealer_get = c.HTTP_METHOD == 'GET' \
+                        and c.PAGE_PATH in ['/preregistration/dealer_registration', '/preregistration/post_dealer']
         is_dealer_post = c.HTTP_METHOD == 'POST' and \
             int(kwargs.get('badge_type', 0)) == c.PSEUDO_DEALER_BADGE and \
             int(kwargs.get('tables', 0)) > 0

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -122,7 +122,7 @@ class Root:
             'id': id
         }
 
-    @cherrypy.expose(['post_form'])
+    @cherrypy.expose(['post_form', 'post_dealer'])
     @redirect_if_at_con_to_kiosk
     @check_if_can_reg
     def form(self, session, message='', edit_id=None, **params):
@@ -145,6 +145,9 @@ class Root:
             group_params[field_name] = params.get('group_{}'.format(field_name), '')
             if params.get('copy_address'):
                 params[field_name] = group_params[field_name]
+
+        if c.PAGE == 'post_dealer':
+            params['badge_type'] = c.PSEUDO_DEALER_BADGE
 
         if edit_id is not None:
             attendee, group = self._get_unsaved(

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -5,7 +5,7 @@
 <div class="masthead"></div>
 
 <div class="panel panel-default">
-  <div class="panel-body">
+  <div class="panel-body">{{ attendee.badge_type_label }}
     {% if attendee.is_dealer %}
       <h2 class="text-center">Dealer Application</h2>
     {% else %}
@@ -47,8 +47,9 @@
       </div>
     {% endif %}
 
-{#- The action is set to "post_form" in order to bypass the NGINX cache. -#}
-<form method="post" action="post_form" class="form-horizontal" role="form">
+{#- The action is set to "post_form" or "post_dealer" in order to bypass the NGINX cache. -#}
+{% set post_action = 'post_dealer' if attendee.is_dealer else 'post_form' %}
+<form method="post" action="{{ post_action }}" class="form-horizontal" role="form">
 
 {% if edit_id %}
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -76,7 +76,7 @@
             row: '#badge-types',
             selector: '.badge-type-selector',
             options: [{
-                title: '{% if c.PAGE_PATH in ["/preregistration/form", "/preregistration/post_form", "/preregistration/dealer_registration"] or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
+                title: '{% if c.PAGE_PATH in ["/preregistration/form", "/preregistration/post_form", "/preregistration/dealer_registration", "/preregistration/post_dealer"] or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
                 description: 'Allows access to the convention for its duration.',
                 extra: 0,
                 badge_type: '{{ c.ATTENDEE_BADGE }}',

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -2,7 +2,7 @@
 
 {#- Setting some variables to keep the size of conditional clauses smaller. -#}
 {%- set is_prereg_form = c.PAGE_PATH in ['/preregistration/form', '/preregistration/post_form'] -%}
-{%- set is_prereg_dealer = c.PAGE_PATH in ['/preregistration/dealer_registration'] or attendee and attendee.badge_type == c.PSEUDO_DEALER_BADGE -%}
+{%- set is_prereg_dealer = c.PAGE_PATH in ['/preregistration/dealer_registration', 'preregistration/post_dealer'] or attendee and attendee.badge_type == c.PSEUDO_DEALER_BADGE -%}
 {%- set is_prereg_confirm_email_enabled = (is_prereg_form or is_prereg_dealer) and c.PREREG_CONFIRM_EMAIL_ENABLED -%}
 {%- set is_after_request_hotel = c.AFTER_PREREG_REQUEST_HOTEL_INFO_DEADLINE -%}
 {%- set is_after_hotel_email = c.AFTER_PREREG_HOTEL_INFO_EMAIL_DATE -%}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/236. Unfortunately, fields are not preserved. There seems to be no way to properly fix this without a major refactor to the prereg form's functionality.