### PR TITLE
Add charge amount and cost breakdown to group page

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -450,6 +450,7 @@ class Root:
             raise HTTPRedirect('group_members?id={}&message={}', group.id, message)
         return {
             'group':   group,
+            'upgraded_badges': len([a for a in group.attendees if a.badge_type in c.BADGE_TYPE_PRICES]),
             'charge':  charge,
             'message': message
         }

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -71,9 +71,24 @@
     {% if group.status == c.APPROVED %}
       <div class="alert alert-success">
         Congratulations, your dealer application has been <strong>approved</strong>!
-          {% if group.amount_unpaid %}
-              {{ stripe_form('process_group_payment',charge) }}
+        {% if group.cost %}
+        <br/><br/>Here is your group's cost breakdown:
+        <ul>
+          {% if group.auto_recalc %}
+          <li>${{ '%0.2f' % group.table_cost }} for {{ group.tables }} table{{ group.tables|pluralize }}</li>
+          <li>${{ '%0.2f' % group.badge_cost }} for {{ group.badges }} badge{{ group.badges|pluralize }}
+            {% if upgraded_badges %}(including {{ upgraded_badges }} upgraded badge{{ upgraded_badges|pluralize }}){% endif %}</li>
+          {% else %}
+          <li>${{ '%0.2f' % group.cost }} total cost</li>
           {% endif %}
+          <li>${{ '%0.2f' % group.amount_paid }} paid{% if group.amount_unpaid %} so far</li>
+          <li>${{ '%0.2f' % group.amount_unpaid }} unpaid</li>
+        </ul>
+              <br/>{{ stripe_form('process_group_payment',charge) }}
+        {% else %}
+        </li></ul>
+          {% endif %}
+        {% endif %}
         {% elif group.status == c.CANCELLED %}
       <div class="alert alert-info">
         You have <strong>cancelled</strong> your dealer application. If this was a mistake, please contact us at


### PR DESCRIPTION
Implements feedback from https://github.com/MidwestFurryFandom/mff-rams-plugin/pull/119 as much as possible. We now show a cost breakdown for any dealer that has a cost, specifically mentioning if there are upgraded badges.