### PR TITLE
Escape th names to prevent jQuery errors in DataTable tables

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -287,7 +287,7 @@
                         var header_name = $(table.column(colIdx).header()).text();
 
                         // Is there a filter set up for this?
-                        var filter_span = $('#' + header_name.toLowerCase() + '_filter');
+                        var filter_span = $('*[id="' + header_name.toLowerCase() + '_filter"]');
 
                         if($(filter_span).length) {
                         // Create the select list and search operation


### PR DESCRIPTION
When we used the $('#id') syntax, any unusual characters in the text of a header would trip up jQuery. We change it to the functionally-equivalent $(*[id="id"]) syntax so we can escape the header name, letting us have anything we want for a header name.