### PR TITLE
Search first and last name for two-word search terms

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1025,7 +1025,9 @@ class Session(SessionManager):
                     last, first = first.strip(','), last
                 name_cond = attendees.icontains_condition(first_name=first, last_name=last)
                 legal_name_cond = attendees.icontains_condition(legal_name="{}%{}".format(first, last))
-                return attendees.filter(or_(name_cond, legal_name_cond))
+                first_name_cond = attendees.icontains_condition(first_name=terms)
+                last_name_cond = attendees.icontains_condition(last_name=terms)
+                return attendees.filter(or_(name_cond, legal_name_cond, first_name_cond, last_name_cond))
 
             elif len(terms) == 1 and terms[0].endswith(','):
                 last = terms[0].rstrip(',')


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/223. We had built in an assumption that if a search term was two words long, the first word would be the attendee's first name and the second word would be their last name (or vice-versa if there was a comma). This broke down for people with multi-word last names, so now we also check the search text against just first and just last name.