### PR TITLE
Move changes to is_dealer expression back to main plugin

### DIFF
--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -123,11 +123,12 @@ class Group(MagModel, TakesPaymentMixin):
             self.tables
             and self.tables != '0'
             and self.tables != '0.0'
-            and (not self.registered or self.amount_paid or self.cost))
+            and (not self.registered or self.amount_paid or self.cost
+                 or self.status != c.UNAPPROVED))
 
     @is_dealer.expression
     def is_dealer(cls):
-        return and_(cls.tables > 0, or_(cls.amount_paid > 0, cls.cost > 0))
+        return and_(cls.tables > 0, or_(cls.amount_paid > 0, cls.cost > 0, cls.status != c.UNAPPROVED))
 
     @hybrid_property
     def is_unpaid(self):


### PR DESCRIPTION
Using the event plugin to override a hybrid property doesn't actually work (and it's not clear it ever did), so we're moving this into the main plugin. It should be safe to change it.