### PR TITLE
Fix radiobutton group alignment in forms

### DIFF
--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -89,7 +89,7 @@
 
 
 {% macro button_radio_opts(field_name, choices, suffix='', default='', is_readonly=False, is_required=False) -%}
-  <div data-toggle="buttons" class="btn-group btn-group-toggle">
+  <div data-toggle="buttons" class="btn-group btn-group-toggle form-control-static">
     {% for choice in choices -%}
       {%- set value = choice[0] -%}
       {%- set label = choice[1] -%}


### PR DESCRIPTION
Our radio buttons were misaligned on our forms, so they needed an extra class to get back in line.