### PR TITLE
Remove old one-off "Waitlist Exhausted" email

### DIFF
--- a/uber/templates/emails/dealers/waitlist_closing.txt
+++ b/uber/templates/emails/dealers/waitlist_closing.txt
@@ -1,5 +1,0 @@
-{{ group.leader.first_name }}, 
-
-I am sorry to inform you that only one space opened up for the waitlist, and unfortunately, your group ({{ group.name }}) did not make it into {{ c.EVENT_NAME }} Marketplace this year, which is why your application is now being declined.  Please try again next year.  Registration opens up at Otakon and online at the same time.  Again, I am very sorry that you did not make it into the Marketplace this year.
-
-{{ c.MARKETPLACE_EMAIL_SIGNATURE }}


### PR DESCRIPTION
We haven't sent this email in at least two years that I can tell. Admins get notifications that it hasn't been approved -- removing it is the only way to stop that.