### PR TITLE
Fix dealer registration validation and handling

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -355,6 +355,8 @@ def zip_code(attendee):
 def emergency_contact(attendee):
     if not attendee.ec_name:
         return 'Please tell us the name of your emergency contact.'
+    if not attendee.ec_phone:
+        return 'Please give us an emergency contact phone number.'
     if not attendee.international and _invalid_phone_number(attendee.ec_phone):
         if c.COLLECT_FULL_ADDRESS:
             return 'Enter a 10-digit US phone number or include a ' \

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -157,6 +157,7 @@ class Root:
                     group_params[field_name] = params.get('group_{}'.format(field_name), '')
                     if params.get('copy_address'):
                         params[field_name] = group_params[field_name]
+                        attendee.apply(params)
 
                 group = session.group(group_params, ignore_csrf=True, restricted=True)
 
@@ -186,12 +187,13 @@ class Root:
             }
 
         if 'first_name' in params:
-            message = check(attendee, prereg=True)
-            if not message and attendee.badge_type == c.PSEUDO_DEALER_BADGE:
+            if attendee.badge_type == c.PSEUDO_DEALER_BADGE:
                 message = check(group, prereg=True)
 
+            message = message or check(attendee, prereg=True)
+
             if attendee.badge_type in [c.PSEUDO_GROUP_BADGE, c.PSEUDO_DEALER_BADGE]:
-                message = "Please enter a group name" if not params.get('name') else ''
+                message = "Please enter a group name" if not params.get('name') else message
             else:
                 params['badges'] = 0
                 params['name'] = ''

--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -153,7 +153,7 @@
         </p>
     </div>
 
-    {{ macros.address_form(group, name_prefix="group_") }}
+    {{ macros.address_form(group, name_prefix="group_", is_required=True) }}
 {% endif %}
 
 {% include "groupextra.html" %}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/320 -- if someone was submitting the form as a group or dealer, we were accidentally resetting the variable that stores validation error messages. Also fixes a bug where the dealer address fields weren't actually being copied into the group leader's address fields, and adds validation for emergency contact numbers, which previously could be empty if the attendee was from outside the US.