### PR TITLE
Don't reset # of badges when throwing validation errors for dealers

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -275,6 +275,7 @@ class Root:
         return {
             'message':    message,
             'attendee':   attendee,
+            'badges': params['badges'] if 'badges' in params else 0,
             'group':      group,
             'promo_code_group': promo_code_group,
             'edit_id':    edit_id,

--- a/uber/templates/groupform.html
+++ b/uber/templates/groupform.html
@@ -16,6 +16,8 @@
   $(function() {
       $("select[name=tables]").on('change', updateBadgeMax);
       updateBadgeMax();
+      var selectedBadge = Math.min({{ badges }}, $('select[name=badges] option:last').val());
+      $('select[name=badges] option[value="' + selectedBadge + '"]').prop('selected', true)
   });
 
   </script>


### PR DESCRIPTION
We weren't properly storing the 'badges' selection between page loads, so any validation error would reset it to 1. This is now fixed so dealers won't accidentally submit the form with just one badge when they wanted more.