### PR TITLE
Use "volunteering" and "staffing" on admin form

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -803,11 +803,11 @@
       {% if admin_area %}
         This attendee is
         {% if attendee.is_new or not attendee.staffing %}
-          volunteering
+          {{ (c.VOLUNTEER_RIBBON|string in attendee.ribbon_ints|string)|yesno("volunteering,staffing") }}
           </label>
         {% else %}
           </label>
-          <a href='goto_volunteer_checklist?id={{ attendee.id }}'>volunteering</a>
+          <a href='goto_volunteer_checklist?id={{ attendee.id }}'>{{ (c.VOLUNTEER_RIBBON|string in attendee.ribbon_ints|string)|yesno("volunteering,staffing") }}</a>
         {% endif %}
       {% else %}
         {% if attendee.badge_type == c.STAFF_BADGE %} Yes, I want to staff {{ c.EVENT_NAME }}. {% else %} Sign me up! {% endif %}


### PR DESCRIPTION
The fact that this box said 'volunteering' was confusing, so now it says if the attendee is staffing or volunteering.