### PR TITLE
Add staffing_or_will_be for use in model checks

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -279,7 +279,7 @@ def full_name(attendee):
 
 @validation.Attendee
 def allowed_to_volunteer(attendee):
-    if attendee.staffing \
+    if attendee.staffing_or_will_be \
             and not attendee.age_group_conf['can_volunteer'] \
             and attendee.badge_type != c.STAFF_BADGE \
             and c.PRE_CON:
@@ -373,7 +373,7 @@ def cellphone(attendee):
         return 'Your phone number was not a valid 10-digit US phone number. ' \
             'Please include a country code (e.g. +44) for international numbers.'
 
-    if not attendee.no_cellphone and attendee.staffing and not attendee.cellphone:
+    if not attendee.no_cellphone and attendee.staffing_or_will_be and not attendee.cellphone:
         return "Phone number is required for volunteers (unless you don't own a cellphone)"
 
 
@@ -410,7 +410,7 @@ def group_leadership(attendee):
 
 @validation.Attendee
 def banned_volunteer(attendee):
-    if (c.VOLUNTEER_RIBBON in attendee.ribbon_ints or attendee.staffing) and attendee.full_name in c.BANNED_STAFFERS:
+    if attendee.staffing_or_will_be and attendee.full_name in c.BANNED_STAFFERS:
         return "We've declined to invite {} back as a volunteer, ".format(attendee.full_name) + (
                     'talk to Stops to override if necessary' if c.AT_THE_CON else
                     'Please contact us via {} if you believe this is in error'.format(c.CONTACT_URL))

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -717,6 +717,11 @@ class Attendee(MagModel, TakesPaymentMixin):
     def is_unassigned(cls):
         return cls.first_name == ''
 
+    @property
+    def staffing_or_will_be(self):
+        # This is for use in our model checks -- it includes attendees who are going to be marked staffing
+        return self.staffing or self.badge_type == c.STAFF_BADGE or c.VOLUNTEER_RIBBON in self.ribbon_ints
+
     @hybrid_property
     def is_dealer(self):
         return c.DEALER_RIBBON in self.ribbon_ints or self.badge_type == c.PSEUDO_DEALER_BADGE or (


### PR DESCRIPTION
We have a few flags that end up setting `staffing` to true for attendees, but our model checks would miss these soon-to-be-staff. This fixes that.