### PR TITLE
Add create and update functions for Attendees to the API

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -325,6 +325,7 @@ class MagModel:
             return []
 
         choices = dict(self.get_field(name).type.choices)
+        val = MultiChoice.convert_if_labels(self.get_field(name).type, val)
         return [int(i) for i in str(val).split(',') if i and int(i) in choices]
 
     @suffix_property

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -521,10 +521,8 @@ class Attendee(MagModel, TakesPaymentMixin):
                     and c.VOLUNTEER_RIBBON in old_ribbon and not self.is_dept_head:
                 self.unset_volunteering()
 
-        self._staffing_badge_and_ribbon_adjustments()
-
     @presave_adjustment
-    def _staffing_badge_and_ribbon_adjustments(self):
+    def staffing_badge_and_ribbon_adjustments(self):
         if self.badge_type == c.STAFF_BADGE:
             self.ribbon = remove_opt(self.ribbon_ints, c.VOLUNTEER_RIBBON)
 

--- a/uber/site_sections/import.py
+++ b/uber/site_sections/import.py
@@ -91,18 +91,6 @@ class Root:
                         val = val.strip().lower() not in ('f', 'false', 'n', 'no', '0')
                     else:
                         val = bool(val)
-                elif isinstance(col.type, Choice):
-                    # the export has labels, and we want to convert those back into their
-                    # integer values, so let's look that up (note: we could theoretically
-                    # modify the Choice class to do this automatically in the future)
-                    label_lookup = {val: key for key, val in col.type.choices.items()}
-                    val = label_lookup[val]
-                elif isinstance(col.type, MultiChoice):
-                    # the export has labels separated by ' / ' and we want to convert that
-                    # back into a comma-separate list of integers
-                    label_lookup = {val: key for key, val in col.type.choices}
-                    vals = [label_lookup[label] for label in val.split(' / ')]
-                    val = ','.join(map(str, vals))
                 elif isinstance(col.type, UTCDateTime):
                     # we'll need to make sure we use whatever format string we used to
                     # export this date in the first place


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/306. This includes a lot of upgrades to the custom database types that we have. Any type that we define in this system can now accept strings as inputs, including strings of labels instead of the underlying special integer values. I couldn't do this to the UTCDateTime, Date, or Boolean columns, so we process those values inside the API instead.

You can update basically any field, as far as I know. Some types of fields have not gotten the special treatment that allows you to use their names instead of IDs -- for example, if you wish to update someone's assigned departments, you'll need to set their `assigned_depts_ids` to a comma-separated list of the UUIDs of departments, not their names. You can retrieve the IDs using the existing `dept.list()` API call. But for the most common column types, you can just use the labels/names.

Also keep in mind that when setting things like ribbons, you are _replacing_ the list of ribbons that attendee has. Being able to add/remove individual ribbons was out of scope for this iteration.