### PR TITLE
Add missing badge name field to on-site registration form

### DIFF
--- a/uber/templates/registration/register.html
+++ b/uber/templates/registration/register.html
@@ -15,6 +15,7 @@
         {{ attendee_fields.badge_type }}
         {{ attendee_fields.name }}
         {{ attendee_fields.extra_donation }}
+        {{ attendee_fields.badge_printed_name }}
         {{ attendee_fields.staffing }}
         {{ attendee_fields.job_interests }}
         {{ attendee_fields.age }}


### PR DESCRIPTION
This fixes #359 