### PR TITLE
Revert "Force 523e3d243395 to depend on promo code group migration"

### DIFF
--- a/alembic/versions/e0c620d341cb_add_cost_tracking_and_registered_date_.py
+++ b/alembic/versions/e0c620d341cb_add_cost_tracking_and_registered_date_.py
@@ -11,7 +11,7 @@ Create Date: 2019-03-07 03:00:57.592885
 revision = 'e0c620d341cb'
 down_revision = 'e372e4daf771'
 branch_labels = None
-depends_on = '523e3d243395'
+depends_on = None
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
This reverts commit c875fd0d9fec6e5d3aeb891d38816ef73972b017.

It was blowing up staging, alas. Migrations are not great.