### PR TITLE
Make JIRA feedback button configurable

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -292,6 +292,12 @@ hours_for_refund = integer(default=24)
 # This setting determines how many days in advance we begin tracking setup shifts.
 setup_shift_days = integer(default=5)
 
+# Some events may wish to have JIRA integration enabled so that admins can
+# easily file issues. Turn this on and set the JavaScript source URLs to
+# enable this integration.
+jira_enabled = boolean(default=False)
+jira_collector_urls = string_list(default=list('https://jira.magfest.net/s/7cedd06b64911e869dc2b32a6477230c-T/kby73n/73019/6d39734591565d7d1928c35b4400d05a/2.0.23/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a192a515', 'https://jira.magfest.net/s/7cedd06b64911e869dc2b32a6477230c-T/kby73n/73019/6d39734591565d7d1928c35b4400d05a/2.0.23/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a9568879'))
+
 # Some events wish to be able to freely edit badge numbers throughout the year,
 # without worrying about number collisions. Others want to restrict number
 # changes. Set this to True for the former, and False for the latter.

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -142,9 +142,10 @@
     </style>
 
     {% block feedback_javascript %}
-      {% if admin_area %}
-      <script type="text/javascript" async="async" src="https://jira.magfest.net/s/7cedd06b64911e869dc2b32a6477230c-T/kby73n/73019/6d39734591565d7d1928c35b4400d05a/2.0.23/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a192a515"></script>
-      <script type="text/javascript" async="async" src="https://jira.magfest.net/s/7cedd06b64911e869dc2b32a6477230c-T/kby73n/73019/6d39734591565d7d1928c35b4400d05a/2.0.23/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=a9568879"></script>
+      {% if admin_area and c.JIRA_ENABLED %}
+      {% for url in c.JIRA_COLLECTOR_URLS %}
+      <script type="text/javascript" async="async" src="{{ url }}"></script>
+      {% endfor %}
       <script type="text/javascript">
         $(function() {
           window.ATL_JQ_PAGE_PROPS = $.extend(window.ATL_JQ_PAGE_PROPS || {}, {
@@ -406,6 +407,7 @@
                 <div class="collapse navbar-collapse" id="main-navbar-collapse-1">
                     <ul class="nav navbar-nav navbar-right">
                       {% block feedback_menu %}
+                      {% if c.JIRA_ENABLED %}
                         <li class="dropdown">
                           <a href="#" class="dropdown-toggle" data-toggle="dropdown" title="Submit feedback">
                             <span class="glyphicon glyphicon-send"></span>
@@ -415,6 +417,7 @@
                             <li><a id="request-an-improvement" href="#" title="Request an Improvement">Request an Improvement</a></li>
                           </ul>
                         </li>
+                      {% endif %}
                       {% endblock %}
                         <li><a href="{{ c.ADMIN_GUIDE_URL }}" target="admin_guide"><span title="Admin Guide" class="glyphicon glyphicon-question-sign"></span></a></li>
                         <li><a href="../accounts/sitemap"><span title="Site Map" class="glyphicon glyphicon-road"></span></a></li>


### PR DESCRIPTION
The paper airplane in the admin area was hard-coded to use MAGFest's JIRA. It's now configurable, and set to not show by default.