### PR TITLE
Add payment workflow to prereg checkin

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -765,17 +765,15 @@ class Attendee(MagModel, TakesPaymentMixin):
         Returns None if we are ready for checkin, otherwise a short error
         message why we can't check them in.
         """
-        if self.paid == c.NOT_PAID:
-            return "Not paid"
 
         # When someone claims an unassigned group badge on-site, they first
         # fill out a new registration which is paid-by-group but isn't assigned
         # to a group yet (the admin does that when they check in).
-        if self.badge_status != c.COMPLETED_STATUS and not (
-                self.badge_status == c.NEW_STATUS
-                and self.paid == c.PAID_BY_GROUP
-                and not self.group_id):
-            return "Badge status"
+        if self.badge_status not in [c.COMPLETED_STATUS, c.NEW_STATUS]:
+            return "Badge status is {}".format(self.badge_status_label)
+        
+        if self.placeholder:
+            return "Placeholder badge"
 
         if self.is_unassigned:
             return "Badge not assigned"

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -424,7 +424,8 @@ class Root:
 
         return {
             'attendee': attendee,
-            'groups': groups
+            'groups': groups,
+            'Charge': Charge,
         }
 
     @check_for_encrypted_badge_num
@@ -460,7 +461,7 @@ class Root:
             'paid':       attendee.paid_label,
             'age_group':  attendee.age_group_conf['desc'],
             'pre_badge':  pre_badge,
-            'checked_in': attendee.checked_in and hour_day_format(attendee.checked_in)
+            'checked_in': attendee.checked_in and hour_day_format(attendee.checked_in),
         }
 
     @csrf_protected
@@ -789,16 +790,13 @@ class Root:
 
     @ajax
     def mark_as_paid(self, session, id, payment_method):
-        if cherrypy.session['reg_station'] == 0:
-            return {'success': False, 'message': 'Reg station 0 is for prereg only and may not accept payments'}
-
         attendee = session.attendee(id)
         attendee.paid = c.HAS_PAID
         if int(payment_method) == c.STRIPE_ERROR:
             attendee.for_review += "Automated message: Stripe payment manually verified by admin."
         attendee.payment_method = payment_method
         attendee.amount_paid = attendee.total_cost
-        attendee.reg_station = cherrypy.session['reg_station']
+        attendee.reg_station = cherrypy.session.get('reg_station', 1)
         session.commit()
         return {'success': True, 'message': 'Attendee marked as paid.', 'id': attendee.id}
 

--- a/uber/templates/check_in.html
+++ b/uber/templates/check_in.html
@@ -7,6 +7,7 @@ $(function() {
             modal: true,
             buttons: [{
                 text: 'Save & Check In',
+                id: "check_in_btn",
                 click: function() {
                     checkIn();
                     $dialog.dialog('close');

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -24,6 +24,12 @@ var toggleMarkButton = function (dropdown) {
         $button.attr('disabled', 'disabled');
     }
 };
+var loadCheckInForm = function () {
+    $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}', function () {
+                    $('#check_in_btn').show();
+                    createDateTextEntries();
+                });
+}
 $("form[action='manual_reg_charge']").prop('target', 'stripe_frame');
 $("form[action='mark_as_paid']").submit(function (e) {
     e.preventDefault();
@@ -41,8 +47,7 @@ $("form[action='mark_as_paid']").submit(function (e) {
             var message = json.message;
             if (json.success) {
                 toastr.info(message);
-                $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}');
-                $('#check_in_btn').show();
+                loadCheckInForm();
             } else {
                 toastr.error(message);
             }
@@ -61,8 +66,7 @@ $('#stripe_frame').load(function() {
         var response = $.parseJSON(responseText);
         if (response['success'] == true) {
             toastr.info(response['message']);
-            $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}');
-            $('#check_in_btn').show();
+            loadCheckInForm();
         } else {
             toastr.error('', response['message'], {timeOut: 1000});
         }

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -1,3 +1,81 @@
+{% if attendee.amount_unpaid %}
+<div class="center text-center">
+<h4>{{ attendee.full_name }} currently owes <strong>${{ attendee.amount_unpaid }}</strong>.</h4>
+<form method="post" action="mark_as_paid">
+{{ csrf_token() }}
+<input type="hidden" name="id" value="{{ attendee.id }}" />
+<select name="payment_method" onChange="toggleMarkButton(this)">
+    <option value="">Payment Method</option>
+    {{ options(c.NEW_REG_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
+</select>
+    <button class="btn btn-success" type="submit" disabled="disabled">Mark as Paid</button>
+</form>
+
+    <strong>OR</strong> <br/>
+{{ stripe_form('manual_reg_charge', Charge(attendee)) }}
+</div>
+<iframe id="stripe_frame" name="stripe_frame" style="display:none"></iframe>
+<script type="text/javascript">
+var toggleMarkButton = function (dropdown) {
+    var $button = $(dropdown).parent().find(':submit');
+    if ($(dropdown).val()) {
+        $button.removeAttr('disabled');
+    } else {
+        $button.attr('disabled', 'disabled');
+    }
+};
+$("form[action='manual_reg_charge']").prop('target', 'stripe_frame');
+$("form[action='mark_as_paid']").submit(function (e) {
+    e.preventDefault();
+
+    var data = $(this).serialize();
+    var currentForm = $(this);
+
+    $.ajax({
+        method: 'POST',
+        url: '../registration/mark_as_paid',
+        dataType: 'json',
+        data: data,
+        success: function (json) {
+            toastr.clear();
+            var message = json.message;
+            if (json.success) {
+                toastr.info(message);
+                $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}');
+                $('#check_in_btn').show();
+            } else {
+                toastr.error(message);
+            }
+        },
+        error: function () {
+            toastr.error('Unable to connect to server, please try again.');
+        }
+    });
+});
+$('#stripe_frame').load(function() {
+    var responseText = $(this.contentDocument.body).text().trim();
+    this.contentDocument.body.innerHTML = '';
+    
+    if (responseText) {
+        toastr.clear();
+        var response = $.parseJSON(responseText);
+        if (response['success'] == true) {
+            toastr.info(response['message']);
+            $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}');
+            $('#check_in_btn').show();
+        } else {
+            toastr.error('', response['message'], {timeOut: 1000});
+        }
+    }
+});
+$().ready(function() {
+    $('#check_in_btn').hide();
+    $('select[name=payment_method]').each(function (i, dropdown) {
+        toggleMarkButton(dropdown);
+    });
+})
+</script>
+{% else %}
 <form action="/" id="check_in_form_{{ attendee.id }}">
     {{ csrf_token() }}
     <input type="hidden" name="id" value="{{ attendee.id }}" />
@@ -107,3 +185,4 @@
     {% endblock checkin_fields %}
 </table>
 </form>
+{% endif %}


### PR DESCRIPTION
The at-door page is super slow, so it's better to just be able to mark an attendee as paid after searching for them in /registration/index. This adds an alternate version of the checkin dialogue that lets you mark them as paid or process a stripe payment for their registration.
![image](https://user-images.githubusercontent.com/7198215/69602193-b7460180-0fe4-11ea-83e9-9f336834b82e.png)

Once an attendee is marked as paid, the check-in modal seamlessly reloads to show the check-in form.
![image](https://user-images.githubusercontent.com/7198215/69602508-d09b7d80-0fe5-11ea-9b5d-0c54a11631f4.png)
