### PR TITLE
Add check-in and payment buttons to attendee details page

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -156,9 +156,9 @@ credit = "Credit Card"
 cash   = "Cash"
 stripe = "Stripe"
 square = "Square"
-manual = "Stripe"
+manual = "Stripe (Manual)"
 group  = "Group"
-stripe_error = "Stripe"
+stripe_error = "Stripe (Error Override)"
 
 [[fee_payment_method]]
 cash   = "cash"

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -159,9 +159,9 @@ class Root:
                         stay_on_form = True
                     else:
                         attendee.checked_in = localized_now()
-                        message += '{} saved and checked in as {}{}'.format(
+                        message = '{} saved and checked in as {}{}'.format(
                             attendee.full_name, attendee.badge, attendee.accoutrements)
-                        stay_on_form = True
+                        stay_on_form = False
                         
                 if stay_on_form:
                     raise HTTPRedirect('form?id={}&message={}&return_to={}', attendee.id, message, return_to)

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -275,7 +275,7 @@
               won't be rendered. To overcome this, we attempt to instantiate
               datetextentries every time the datatable finishes drawing.
             -#}
-            var createDateTextEntries = function() {
+            createDateTextEntries = function() {
                 {# Only create datetextentry if it wasn't already created. -#}
                 $('.date:not(.jq-dte .date)').datetextentry({
                     field_order: 'MDY',

--- a/uber/templates/check_in.html
+++ b/uber/templates/check_in.html
@@ -1,90 +1,70 @@
-<div class="dialog-form" id="checkin-dialog" title="Quick Check-In"></div>
+<div class="modal fade" id="checkin_modal" role="dialog">
+    <div class="modal-dialog modal-lg">
+        <!-- Modal content-->
+        <div class="modal-content"><div style='padding: 10px;'>Loading...</div></div>
+    </div>
+</div>
+
 <script type="text/javascript">
-$(function() {
-        var $dialog = $('#checkin-dialog').dialog({
-            autoOpen: false,
-            width: 666,
-            modal: true,
-            buttons: [{
-                text: 'Save & Check In',
-                id: "check_in_btn",
-                click: function() {
-                    checkIn();
-                    $dialog.dialog('close');
-                }
-            }, {
-                text: 'Cancel',
-                click: function () {
-                    $dialog.dialog('close');
-                }
-            }]
-        });
+checkInModal = $('#checkin_modal')
 
-        $('.attendee-checkin').on('click', function () {
-            var attendeeId = $(this).attr('data-attendee-id');
-            $dialog.data('attendeeId', attendeeId).text('Loading...').dialog('open');
-            $.ajax({
-                method: 'GET',
-                dataType: 'html',
-                url: '../registration/check_in_form',
-                data: {id: attendeeId},
-                success: function (response) {
-                    $dialog.html(response);
-                    $dialog.find('input.num').keypress(function (event) {
-                        if (event.keyCode === 13) {  // Enter key
-                            event.preventDefault();
-                            checkIn(attendeeId);
-                            $dialog.dialog('close');
-                        }
-                    });
-                    $dialog.find('input.date').datetextentry({
-                        field_order: 'MDY',
-                        show_tooltips: false
-                    });
-                    $dialog.dialog('option', 'position', {at: 'center', of: window});
-                },
-                error: function () {
-                    $dialog.text('Unexpected error pulling up attendee form - please try again.');
-                }
+var loadCheckInModal = function (attendeeID) {
+    checkInModal.modal({show:true});
+    $('#checkin_modal .modal-content').load('../registration/check_in_form?id=' + attendeeID, function() {
+        if ($('.check-in').length) {
+            checkInModal.find('input.date').datetextentry({
+                field_order: 'MDY',
+                show_tooltips: false
             });
-        });
+        } else {
+            toastr.error("Form loading failed.");
+            checkInModal.modal('hide');
+        }
     });
+};
 
-    var checkIn = function () {
-        var id = $('#checkin-dialog').data('attendeeId');
-        $.ajax({
-            method: 'POST',
-            url: '../registration/check_in',
-            dataType: 'json',
-            data: $("#check_in_form_" + id).serialize(),
-            success: function (json) {
-                toastr.clear();
-                var message = json.message;
-                if (json.success) {
-                    message += ' &nbsp; <a href="#" onClick="undoCheckIn(\'' + id + '\', ' + json.pre_badge + ') ; return false">Undo</a>';
-                    $('#paid_' + id).html(json.paid);
-                    $('#cin_' + id).html(json.checked_in);
-                    $('#age_' + id).parent().html(json.age_group);
-                    $('#num_' + id).parent().html(json.badge);
-                    toastr.info(message);
-                } else {
-                    toastr.error(message);
-                }
-                if (json.increment) {
-                    $('#checkin_count').html(1 + parseInt($("#checkin_count").text()));
-                }
-            },
-            error: function () {
-                toastr.error('Unable to connect to server, please try again.');
+// Hide modal on Esc keydown
+$(document).keydown(function(event) { 
+    if (event.keyCode == 27) { 
+        checkInModal.modal('hide');
+    }
+});
+
+var checkIn = function () {
+    var id = checkInModal.data('attendeeID');
+    $.ajax({
+        method: 'POST',
+        url: '../registration/check_in',
+        dataType: 'json',
+        data: $("#check_in_form_" + id).serialize(),
+        success: function (json) {
+            toastr.clear();
+            var message = json.message;
+            if (json.success) {
+                message += ' &nbsp; <a href="#" onClick="undoCheckIn(\'' + id + '\', ' + json.pre_badge + ') ; return false">Undo</a>';
+                $('#paid_' + id).html(json.paid);
+                $('#cin_' + id).html(json.checked_in);
+                $('#age_' + id).parent().html(json.age_group);
+                $('#num_' + id).parent().html(json.badge);
+                toastr.info(message);
+            } else {
+                toastr.error(message);
             }
-        });
-    };
-    var undoCheckIn = function (id, pre_badge) {
-        $.post('undo_checkin', {id: id, csrf_token: csrf_token, pre_badge: pre_badge}, function(s) {
-            var sep = location.href.indexOf('?') === -1 ? '?' : '&';
-            location.href += sep + 'message=' + encodeURIComponent(s);
-        });
-    };
+            if (json.increment) {
+                $('#checkin_count').html(1 + parseInt($("#checkin_count").text()));
+            }
+        },
+        error: function () {
+            toastr.error('Unable to connect to server, please try again.');
+        }
+    });
+};
+var undoCheckIn = function (id, pre_badge) {
+    $.post('undo_checkin', {id: id, csrf_token: csrf_token, pre_badge: pre_badge}, function(s) {
+        var sep = location.href.indexOf('?') === -1 ? '?' : '&';
+        location.href += sep + 'message=' + encodeURIComponent(s);
+    });
+};
 </script>
 <style type="text/css">
     table.check-in td {

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1488,18 +1488,18 @@ $(function(){
 
 {% set payment_method %}
 {% set read_only = payment_method_ro or page_ro %}
-{% if admin_area and attendee.payment_method %}
+{% if admin_area and (attendee.payment_method or c.AT_THE_CON) %}
   <div class="form-group">
     <label for="payment_method" class="col-sm-3 control-label">Payment Method</label>
     {% call macros.read_only_if(read_only, attendee.payment_method) %}
     <div class="col-sm-3">
       <select id="payment_method" name="payment_method" class="form-control">
-        {{ options(c.NEW_REG_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
+        {{ options(c.PAYMENT_METHOD_OPTS,attendee.payment_method) }}
       </select>
     </div>
   {% endcall %}
   </div>
-{% elif c.AT_THE_CON %}
+{% elif not admin_area and c.AT_THE_CON %}
   <script type="text/javascript">
       var maybeBold = function() {
           var $emailLabel = $('#email').parents('.form-group').find('label');

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -1,5 +1,10 @@
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal">&times;</button>
+  <h4 class="modal-title">Attendee Check-In{% if attendee.first_name %} - {{ attendee.full_name }}{% endif %}</h4>
+  </div>
+  <div class="modal-body">
 {% if attendee.amount_unpaid %}
-<div class="center text-center">
+<div class="center text-center check-in">
 <h4>{{ attendee.full_name }} currently owes <strong>${{ attendee.amount_unpaid }}</strong>.</h4>
 <form method="post" action="mark_as_paid">
 {{ csrf_token() }}
@@ -15,6 +20,10 @@
 {{ stripe_form('manual_reg_charge', Charge(attendee)) }}
 </div>
 <iframe id="stripe_frame" name="stripe_frame" style="display:none"></iframe>
+</div>
+<div class="modal-footer">
+  <div class="form-group">
+  <div class="pull-right">
 <script type="text/javascript">
 var toggleMarkButton = function (dropdown) {
     var $button = $(dropdown).parent().find(':submit');
@@ -25,10 +34,9 @@ var toggleMarkButton = function (dropdown) {
     }
 };
 var loadCheckInForm = function () {
-    $('#checkin-dialog').load('check_in_form?id={{ attendee.id }}', function () {
-                    $('#check_in_btn').show();
-                    createDateTextEntries();
-                });
+    $('#checkin_modal').load('check_in_form?id={{ attendee.id }}', function () {
+        createDateTextEntries();
+    });
 }
 $("form[action='manual_reg_charge']").prop('target', 'stripe_frame');
 $("form[action='mark_as_paid']").submit(function (e) {
@@ -73,120 +81,147 @@ $('#stripe_frame').load(function() {
     }
 });
 $().ready(function() {
-    $('#check_in_btn').hide();
     $('select[name=payment_method]').each(function (i, dropdown) {
         toggleMarkButton(dropdown);
     });
 })
 </script>
 {% else %}
-<form action="/" id="check_in_form_{{ attendee.id }}">
+<form action="/" id="check_in_form_{{ attendee.id }}" role="form" class="form-horizontal check-in">
     {{ csrf_token() }}
     <input type="hidden" name="id" value="{{ attendee.id }}" />
-<table class="check-in">
     {% block checkin_fields %}
-    <tr>
-        <td>Name:</td>
-        <td>{{ attendee|form_link }}</td>
-    </tr>
+    <div class="form-group">
+    <label for="name" class="col-sm-3 control-label">Name</label>
+    <div class="col-sm-6">
+        {{ attendee|form_link }}
+    </div>
+    </div>
     {% if c.COLLECT_EXACT_BIRTHDATE %}
-        <tr>
-            <td>Birthdate</td>
-            <td>
+        <div class="form-group">
+            <label for="birthdate" class="col-sm-3 control-label">Date of Birth</label>
+            <div class="col-sm-6">
                 <input type="text" id="checkin-birthdate" name="birthdate" class="date" value="{{ attendee.birthdate|datetime("%Y-%m-%d")}}" />
-            </td>
-        </tr>
+            </div>
+        </div>
          {% if attendee.birthdate %}
-            <tr>
-                <td>Age Group:</td>
-                <td>{{ attendee.age_group_conf.desc }}</td>
-            </tr>
+            <div class="form-group">
+                <label for="age_group" class="col-sm-3 control-label">Age Group</label>
+                <div class="col-sm-6">
+                <div class="form-control-static">{{ attendee.age_group_conf.desc }}</div>
+                </div>
+            </div>
         {% endif %}
     {% else %}
-        <tr>
-            <td>Age Group:</td>
-            <td>
+        <div class="form-group">
+            <label for="age_group" class="col-sm-3 control-label">Age Group</label>
+            <div class="col-sm-6">
                 <select id="checkin-age">
                     {{ options(c.AGE_GROUP_OPTS,attendee.age_group) }}
                 </select>
-            </td>
-        </tr>
+            </div>
+        </div>
     {% endif %}
     {% if attendee.paid == c.PAID_BY_GROUP and not attendee.group_id %}
-        <tr>
-            <td>Group:</td>
-            <td>
+        <div class="form-group">
+            <label for="group" class="col-sm-3 control-label">Group</label>
+            <div class="col-sm-6">
                 <select id="checkin-group" name="group_id">
                     <option value="">No Group</option>
                     {{ options(groups,attendee.group_id) }}
                 </select>
-            </td>
-        </tr>
+            </div>
+        </div>
     {% endif %}
-    <tr>
-        <td>Email:</td>
-        <td>{{ attendee.email }}</td>
-    </tr>
-    <tr>
-        <td>Zipcode:</td>
-        <td>{{ attendee.zip_code }}</td>
-    </tr>
-    <tr>
-        <td>Emergency Contact:</td>
-        <td>{{ attendee.ec_name }} <span class="pull-right">{{ attendee.ec_phone }}</span></td>
-    </tr>
+    <div class="form-group">
+        <label for="email" class="col-sm-3 control-label">Email</label>
+        <div class="col-sm-6">
+            <div class="form-control-static">{{ attendee.email }}</div>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="zip_code" class="col-sm-3 control-label">Zipcode</label>
+        <div class="col-sm-6">
+        <div class="form-control-static">{{ attendee.zip_code }}</div>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="ec_name" class="col-sm-3 control-label">Emergency Contact</label>
+        <div class="col-sm-6">
+            <div class="form-control-static">{{ attendee.ec_name }} (Phone #: {{ attendee.ec_phone }})</div>
+        </div>
+    </div>
     {% if c.VOLUNTEER_AGREEMENT_ENABLED and (attendee.staffing or c.VOLUNTEER in attendee.ribbon_ints) %}
-        <tr>
-            <td>Volunteer Agreement:</td>
-            <td>
-              {%- if attendee.agreed_to_volunteer_agreement -%}
+        <div class="form-group">
+            <label for="volunteer_agreement" class="col-sm-3 control-label">Volunteer Agreement</label>
+            <div class="col-sm-6">
+                <div class="form-control-static">
+                {%- if attendee.agreed_to_volunteer_agreement -%}
                 Completed
-              {%- else -%}
+                {%- else -%}
                 <b class="text-danger">Not Completed</b>
-              {%- endif -%}
-            </td>
-        </tr>
+                {%- endif -%}
+                </div>
+            </div>
+        </div>
     {% endif %}
-    <tr>
-        <td>Badge Type:</td>
-        <td>{{ attendee.badge_type_label }}
+    <div class="form-group">
+        <label for="badge_type" class="col-sm-3 control-label">Badge Type</label>
+        <div class="col-sm-6">
+            <div class="form-control-static">{{ attendee.badge_type_label }}
             {% if attendee.ribbon %}
                 ({{ attendee.ribbon_labels|join(", ") }})
             {% endif %}
-        </td>
-    </tr>
+            </div>
+        </div>
+    </div>
     {% if attendee.badge_printed_name %}
-        <tr>
-            <td>Badge Printed Name:</td>
-            <td><input type="text" class="form-control" value="{{ attendee.badge_printed_name }}" name="badge_printed_name" /></td>
-        </tr>
+        <div class="form-group">
+            <label for="badge_printed_name" class="col-sm-3 control-label">Badge Printed Name</label>
+            <div class="col-sm-6"><input type="text" class="form-control" value="{{ attendee.badge_printed_name }}" name="badge_printed_name" /></div>
+        </div>
     {% endif %}
     {% if c.NUMBERED_BADGES %}
-        <tr>
-            <td>Badge Number:</td>
-            <td>
+        <div class="form-group">
+            <label for="badge_num" class="col-sm-3 control-label">Badge Number</label>
                 {% if attendee.badge_num %}
+                <div class="col-sm-6">
+                    <div class="form-control-static">
                     {{ attendee.badge_num }}
                     <input type="hidden" id="checkin-badge" name="badge_num" value="{{ attendee.badge_num }}" />
+                    </div>
                 {% else %}
+                <div class="col-sm-6">
                   # <input class="num" id="checkin-badge" name="badge_num" type="text" size="10" autofocus/>
                 {% endif %}
-            </td>
-        </tr>
+            </div>
+        </div>
     {% endif %}
     {% if attendee.regdesk_info %}
-        <tr>
-            <td><span class="label label-danger">Special Instructions:</span></td>
-            <td>{{ attendee.regdesk_info }}</td>
-        </tr>
+        <div class="form-group">
+            <label for="special_instructions" class="col-sm-3 control-label"><span class="label label-danger">Special Instructions:</span></label>
+            <div class="col-sm-6">
+                <div class="form-control-static">{{ attendee.regdesk_info }}</div>
+            </div>
+        </div>
     {% endif %}
     {% if attendee.amount_extra and c.MERCH_AT_CHECKIN %}
-      <tr>
-        <td><strong>Picked Up Merch?</strong></td>
-        <td><label style="font-weight:normal;"><input type="checkbox" name="got_merch" value="1" /> Yes, this attendee has received their merch</label></td>
-      </tr>
+      <div class="form-group">
+        <label for="merch" class="col-sm-3 control-label"><strong>Picked Up Merch?</strong></label>
+        <div class="col-sm-6"><label style="font-weight:normal;"><input type="checkbox" name="got_merch" value="1" /> Yes, this attendee has received their merch</label></div>
+      </div>
     {% endif %}
     {% endblock checkin_fields %}
-</table>
 </form>
+</div>
+<div class="modal-footer">
+  <div class="form-group">
+  <div class="pull-right">
+      <button type="button" onClick="checkIn()" class="btn btn-primary">Save & Check In</button>
 {% endif %}
+   <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+  </div>
+  </div>
+  </div>
+ 
+</div>

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -2,6 +2,7 @@
 {% import "fields/attendee.html" as attendee_fields with context %}
 {% block title %}Attendee Form - {{ attendee.full_name }}{% endblock %}
 {% block content %}
+{% include "check_in.html" %}
 
 {% include "registration/menu.html" %}
 
@@ -86,7 +87,10 @@
 
 <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
-        <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save + return{% if not return_to %} to search{% endif %}</button>
+    {% if c.AT_THE_CON and not attendee.is_not_ready_to_checkin and not attendee.amount_unpaid %}
+        <button class="btn btn-success" name="save" value="save_check_in">Save & Check In</button>
+    {% endif %}
+        <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save & Return{% if not return_to %} to Search{% endif %}</button>
         <button type="submit" name="save" class="btn btn-primary" value="save">Save</button>
     </div>
 </div>
@@ -114,8 +118,33 @@
         </div>
     {% endif %}
 {% endif %}
-
 </div>
 </div>
-
+{% if c.AT_THE_CON and attendee.amount_unpaid %}
+<div class="alert alert-warning center" role="alert" id="payment-warning">
+<h4>{{ attendee.full_name }} currently owes <strong>${{ attendee.amount_unpaid }}</strong>.</h4>
+{{ stripe_form('manual_reg_charge', Charge(attendee)) }}
+</div>
+<iframe id="stripe_frame" name="stripe_frame" style="display:none"></iframe>
+<script type="text/javascript">
+$("form[action='manual_reg_charge']").prop('target', 'stripe_frame');
+$('#stripe_frame').load(function() {
+    var responseText = $(this.contentDocument.body).text().trim();
+    this.contentDocument.body.innerHTML = '';
+    
+    if (responseText) {
+        toastr.clear();
+        var response = $.parseJSON(responseText);
+        if (response['success'] == true) {
+            window.location.href = '../registration/form?id={{ attendee.id }}&message=' + response['message'];
+        } else {
+            toastr.error('', response['message'], {timeOut: 1000});
+        }
+    }
+});
+$().ready(function() {
+    $('#payment-warning').insertBefore('form[action="form"]');
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -87,7 +87,7 @@
 
 <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
-    {% if c.AT_THE_CON and not attendee.is_not_ready_to_checkin and not attendee.amount_unpaid %}
+    {% if c.AT_THE_CON and not attendee.checked_in and not attendee.is_not_ready_to_checkin and not attendee.amount_unpaid %}
         <button class="btn btn-success" name="save" value="save_check_in">Save & Check In</button>
     {% endif %}
         <button type="submit" name="save" class="btn btn-primary" value="save_return_to_search">Save & Return{% if not return_to %} to Search{% endif %}</button>

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -167,7 +167,7 @@
                         <td>Can't checkin ({{ attendee.is_not_ready_to_checkin }})</td>
                     {% else %}
                         <td id="cin_{{ attendee.id }}">
-                            <button class="attendee-checkin" data-attendee-id="{{ attendee.id }}">Check In</button>
+                            <button class="attendee-checkin btn-sm btn-success" data-attendee-id="{{ attendee.id }}" onClick="loadCheckInModal('{{ attendee.id }}')">Check In</button>
                         </td>
                     {% endif %}
                 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/310. Fixes https://github.com/MidwestFurryFandom/rams/issues/312. Also includes some visual updates, and a fix for the attendee form showing the wrong payment options in at-con mode.

During the event (i.e., `at_the_con` is True), if an attendee has an amount unpaid, we now show a Stripe button at the top of their Details page:
![image](https://user-images.githubusercontent.com/7198215/69704066-bc787e80-10c0-11ea-9ad1-68ada46a24fd.png)

Note that for cash payments, you can enter the payment method and set the "paid" box in their usual place near the bottom of the form:
![image](https://user-images.githubusercontent.com/7198215/69704178-ecc01d00-10c0-11ea-8d4e-afa5868c3564.png)

If the attendee can be checked in, we show a "Save & Check In" button at the bottom of their page:
![image](https://user-images.githubusercontent.com/7198215/69704259-0e210900-10c1-11ea-8ac9-96e757b918cd.png)

After checking someone in, you are redirected back to the search page:
![image](https://user-images.githubusercontent.com/7198215/69705393-796bda80-10c3-11ea-975a-f0ed7dfd875d.png)

The form also detects if saving the attendee makes them unable to check in!
![image](https://user-images.githubusercontent.com/7198215/69705431-8e486e00-10c3-11ea-814d-74e36be0b4b8.png)