### PR TITLE
Remove button to load "At-Door Registrations" page

### DIFF
--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -55,8 +55,6 @@
 
     <div class="col-sm-6 col-md-8">
         <a class="btn btn-primary" href="form?id=None">Add an attendee</a>
-        <a class="btn btn-default" {% if not c.AT_THE_CON %}disabled="disabled"{% endif %}
-           href="new">View Recent At-the-Door Registrations</a>
 
         {% if invalid  %}
             <a class="btn btn-info" href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}">Hide invalid badges</a>


### PR DESCRIPTION
We no longer need this, and it's a huge hit to the system so we shouldn't tempt people with it.