### PR TITLE
Turn off "Pay with credit card at the registration desk" option

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -172,7 +172,7 @@ stripe_error = "Stripe Error Override"
 [[door_payment_method]]
 cash   = "Pay with cash"
 stripe = "Pay with credit card now (faster, can use prereg line)"
-manual = "Pay with credit card at the registration desk"
+#manual = "Pay with credit card at the registration desk"
 
 [[event_location]]
 


### PR DESCRIPTION
Reg asked for this to be removed to speed up at-door check-ins. Note that this only removes the option for attendees; reg volunteers can still process Stripe payments at the door.