### PR TITLE
Send QR code email when in at-con mode

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -538,6 +538,7 @@ AutomatedEmailFixture(
     'reg_workflow/attendee_qrcode.html',
     lambda a: not a.is_not_ready_to_checkin and c.USE_CHECKIN_BARCODE,
     when=days_before(14, c.EPOCH),
+    allow_at_the_con=True,
     ident='qrcode_for_checkin')
 
 


### PR DESCRIPTION
By default almost all emails are locked down when we're at the con, since many stop being relevant. People should still receive their QR codes, though.