### PR TITLE
Revert "Revert "Force 523e3d243395 to depend on promo code group migration""

### DIFF
--- a/alembic/versions/e0c620d341cb_add_cost_tracking_and_registered_date_.py
+++ b/alembic/versions/e0c620d341cb_add_cost_tracking_and_registered_date_.py
@@ -11,7 +11,7 @@ Create Date: 2019-03-07 03:00:57.592885
 revision = 'e0c620d341cb'
 down_revision = 'e372e4daf771'
 branch_labels = None
-depends_on = None
+depends_on = '523e3d243395'
 
 from alembic import op
 import sqlalchemy as sa


### PR DESCRIPTION
Reverts MidwestFurryFandom/rams#362

We now need this change again for spinning up new instances. Just... don't touch prod from 2019.