### PR TITLE
Stop automatically upgrading badges when sold out

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -139,7 +139,7 @@
         selector: '.badge-type-selector',
         options: [],
     };
-    {% set downgrading = not attendee.is_new and attendee.amount_unpaid and 'attendee_donation_form' in attendee.payment_page %}
+    {% set downgrading = not attendee.placeholder and not attendee.is_new and attendee.amount_unpaid and 'attendee_donation_form' in attendee.payment_page %}
     {% if not attendee or attendee.is_new or (attendee.badge_type not in c.BADGE_TYPE_PRICES or (downgrading and attendee.badge_cost - c.BADGE_PRICE <= attendee.amount_unpaid)) %}
         BADGE_TYPES.options.push({
             title: '{% if is_prereg_attendee or is_prereg_dealer or downgrading %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -139,15 +139,16 @@
         selector: '.badge-type-selector',
         options: [],
     };
-    {% if not attendee or attendee.is_new or attendee.badge_type not in c.BADGE_TYPE_PRICES %}
+    {% set downgrading = not attendee.is_new and attendee.amount_unpaid and 'attendee_donation_form' in attendee.payment_page %}
+    {% if not attendee or attendee.is_new or (attendee.badge_type not in c.BADGE_TYPE_PRICES or (downgrading and attendee.badge_cost - c.BADGE_PRICE <= attendee.amount_unpaid)) %}
         BADGE_TYPES.options.push({
-            title: '{% if is_prereg_attendee or is_prereg_dealer or undoing_extra %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
+            title: '{% if is_prereg_attendee or is_prereg_dealer or downgrading %}Attending{% elif attendee %}{{ attendee.ribbon_and_or_badge }}{% endif %}',
             description: 'Allows access to the convention for its duration.',
             extra: 0,
             badge_type: '{{ c.ATTENDEE_BADGE }}',
 
-            price: {{ badge_cost if badge_cost is defined else c.BADGE_PRICE }},
-            {% if c.BADGE_TYPE_PRICES and (attendee.is_new or attendee.badge_type == c.ATTENDEE_BADGE) %}
+            price: {{ badge_cost if badge_cost is defined and not downgrading else c.BADGE_PRICE }},
+            {% if c.BADGE_TYPE_PRICES and (attendee.is_new or attendee.badge_type == c.ATTENDEE_BADGE or downgrading) %}
             onClick: function () {
                 $('input[name="badge_type"]').val('{{ c.ATTENDEE_BADGE }}');
             }
@@ -180,9 +181,8 @@
     {% endif %}
 
     {% for badge_type in c.BADGE_TYPE_PRICES %}
-
         {% if badge_type != c.ATTENDEE_BADGE %}
-            {% if (badge_type != c.SPONSOR_BADGE or c.SPONSOR_BADGE_AVAILABLE) and (badge_type != c.SHINY_BADGE or c.SHINY_BADGE_AVAILABLE) %}
+            {% if (not attendee.is_new and attendee.badge_type == badge_type) or ((badge_type != c.SPONSOR_BADGE or c.SPONSOR_BADGE_AVAILABLE) and (badge_type != c.SHINY_BADGE or c.SHINY_BADGE_AVAILABLE)) %}
                 BADGE_TYPES.options.push({
                     title: '{{ c.BADGES[badge_type] }}',
                     description: 'Donate extra to get an upgraded badge with perks.',


### PR DESCRIPTION
Fixes a fairly large set of issues displaying badges when different badge types were sold out. Most importantly, people who view their page when their existing badge type is sold out will not be automatically upgraded to the next type.

This does NOT fix a handful of edge cases around people who are in the middle of buying badges when a badge type is sold out, as that was out of scope and the default behavior of the app is to just silently give people Attendee badges. There is also one edge case where if a Sponsor cancels an upgrade while Sponsor badges are sold out they cannot downgrade -- the correct behavior needs to be decided on.

Lastly, new attendees whose payments are pending do not count against badge stocks, but existing attendees whose upgrading payments are pending do count against badge stocks -- the correct behavior needs to be decided on, though theoretically most people's payments will just go through and this shouldn't be a common issue.