### PR TITLE
Unify currency formatting

### DIFF
--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -164,7 +164,7 @@ AutomatedEmailFixture(
     Group,
     '{EVENT_NAME} group payment received',
     'reg_workflow/group_confirmation.html',
-    lambda g: (g.amount_paid / 100) == g.cost and g.cost != 0 and g.leader_id,
+    lambda g: g.amount_paid == g.cost * 100 and g.cost != 0 and g.leader_id,
     # query=and_(Group.amount_paid >= Group.cost, Group.cost > 0, Group.leader_id != None),
     needs_approval=False,
     ident='group_payment_received')

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -225,6 +225,7 @@ def percent_of(numerator, denominator):
 
 @JinjaEnv.jinja_filter
 def format_currency(value):
+    value = float(value)
     if int(value) != value:
         return "${:,.2f}".format(value)
     return "${:,}".format(int(value))

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -224,6 +224,13 @@ def percent_of(numerator, denominator):
 
 
 @JinjaEnv.jinja_filter
+def format_currency(value):
+    if int(value) != value:
+        return "${:,.2f}".format(value)
+    return "${:,}".format(value)
+
+
+@JinjaEnv.jinja_filter
 def remove_newlines(string):
     return string.replace('\n', ' ')
 

--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -227,7 +227,7 @@ def percent_of(numerator, denominator):
 def format_currency(value):
     if int(value) != value:
         return "${:,.2f}".format(value)
-    return "${:,}".format(value)
+    return "${:,}".format(int(value))
 
 
 @JinjaEnv.jinja_filter

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -22,6 +22,7 @@ from email_validator import validate_email, EmailNotValidError
 from pockets.autolog import log
 
 from uber.config import c
+from uber.custom_tags import format_currency
 from uber.decorators import prereg_validation, validation
 from uber.models import AccessGroup, AdminAccount, ApiToken, Attendee, ArtShowApplication, ArtShowPiece, \
     AttendeeTournament, Attraction, AttractionFeature, Department, DeptRole, Event, Group, \
@@ -227,14 +228,15 @@ def total_cost_over_paid(attendee):
                 and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
             return 'The date of birth you entered incurs a discount; ' \
                 'please email {} to change your badge and receive a refund'.format(c.REGDESK_EMAIL)
-        return 'You have already paid ${:,.2f}, you cannot reduce your extras below that.'.format(attendee.amount_paid / 100)
+        return 'You have already paid {}, you cannot reduce your extras below that.'.format(
+            format_currency(attendee.amount_paid / 100))
 
 
 @validation.Attendee
 def reasonable_total_cost(attendee):
     if attendee.total_cost >= 999999:
-        return 'We cannot charge ${:,.2f}. Please reduce extras so the total is below $999,999.'.format(
-            attendee.total_cost)
+        return 'We cannot charge ${}. Please reduce extras so the total is below $999,999.'.format(
+            format_currency(attendee.total_cost))
 
 
 @prereg_validation.Attendee

--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -227,7 +227,7 @@ def total_cost_over_paid(attendee):
                 and attendee.age_group_conf['val'] in [c.UNDER_6, c.UNDER_13]:
             return 'The date of birth you entered incurs a discount; ' \
                 'please email {} to change your badge and receive a refund'.format(c.REGDESK_EMAIL)
-        return 'You have already paid ${}, you cannot reduce your extras below that.'.format(attendee.amount_paid / 100)
+        return 'You have already paid ${:,.2f}, you cannot reduce your extras below that.'.format(attendee.amount_paid / 100)
 
 
 @validation.Attendee

--- a/uber/site_sections/art_show_admin.py
+++ b/uber/site_sections/art_show_admin.py
@@ -459,6 +459,7 @@ class Root:
             pdf.cell(53, 24, txt=piece.type_label, ln=1, align="C")
             pdf.set_font("Arial", size=8)
             pdf.set_xy(242 + xplus, 90 + yplus)
+            # Note: we want the prices on the PDF to always have a trailing .00
             pdf.cell(53, 14, txt=('${:,.2f}'.format(piece.opening_bid)) if piece.valid_for_sale else 'N/A', ln=1)
             pdf.set_xy(242 + xplus, 116 + yplus)
             pdf.cell(
@@ -724,6 +725,7 @@ class Root:
                                'Piece {} successfully unclaimed'.format(piece.artist_and_piece_id))
 
     def record_payment(self, session, id, amount='', type=c.CASH):
+        from uber.custom_tags import format_currency
         receipt = session.art_show_receipt(id)
 
         if amount:
@@ -731,10 +733,10 @@ class Root:
 
         if type == str(c.CASH):
             amount = amount or receipt.owed
-            message = 'Cash payment of ${} recorded'.format('%0.2f' % float(amount / 100))
+            message = 'Cash payment of ${} recorded'.format(format_currency(amount / 100))
         else:
             amount = amount or receipt.paid
-            message = 'Refund of ${} recorded'.format('%0.2f' % float(amount / 100))
+            message = 'Refund of ${} recorded'.format(format_currency(amount / 100))
 
         session.add(ArtShowPayment(
             receipt=receipt,

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -863,6 +863,7 @@ class Root:
         return {'id': id, 'message': message}
 
     def abandon_badge(self, session, id):
+        from uber.custom_tags import format_currency
         attendee = session.attendee(id)
         if attendee.amount_paid and not attendee.is_group_leader:
             failure_message = "Something went wrong with your refund. Please contact us at {}."\
@@ -899,8 +900,8 @@ class Root:
                     session.add(session.create_receipt_item(attendee, response.amount, "Self-service refund", stripe_transaction))
                     total_refunded += response.amount
 
-            success_message = "Your refund of ${:,.2f} should appear on your credit card in a few days."\
-                .format(total_refunded / 100)
+            success_message = "Your refund of {} should appear on your credit card in a few days."\
+                .format(format_currency(total_refunded / 100))
             if attendee.paid == c.HAS_PAID:
                 attendee.paid = c.REFUNDED
 

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import joinedload
 
 from uber.config import c
+from uber.custom_tags import format_currency
 from uber.decorators import ajax, all_renderable, attendee_view, check_for_encrypted_badge_num, check_if_can_reg, credit_card, \
     csrf_protected, department_id_adapter, log_pageview, render, site_mappable, public
 from uber.errors import HTTPRedirect
@@ -42,7 +43,7 @@ def pre_checkin_check(attendee, group):
         return attendee.full_name + ' was already checked in!'
 
     if group and attendee.paid == c.PAID_BY_GROUP and group.amount_unpaid:
-        return 'This attendee\'s group has an outstanding balance of ${}'.format('%0.2f' % group.amount_unpaid)
+        return 'This attendee\'s group has an outstanding balance of ${}'.format(format_currency(group.amount_unpaid))
 
     if attendee.paid == c.NOT_PAID:
         return 'You cannot check in an attendee that has not paid.'

--- a/uber/templates/art_show_admin/form.html
+++ b/uber/templates/art_show_admin/form.html
@@ -71,7 +71,7 @@ app, c.PAGE_PATH,
           <span id="amount_paid">
             <div class="input-group">
               <span class="input-group-addon">$</span><input type="text" class="form-control" name="app_paid" value="{{ app_paid|int }}" />
-            </div> (${{ (app.attendee.amount_paid / 100)|int }} of ${{ app.attendee.total_cost }} total)
+            </div> ({{ (app.attendee.amount_paid / 100)|format_currency }} of {{ app.attendee.total_cost|format_currency }} total)
           </span>
           </div>
           {% else %}
@@ -98,7 +98,7 @@ app, c.PAGE_PATH,
                  value="{{ app.overridden_price if app.overridden_price != None else '' }}" />
         </div>
         <span class="col-sm-4 form-control-static">
-          (Base Price: ${{ app.base_price|default(app.potential_cost) }})
+          (Base Price: {{ app.base_price|default(app.potential_cost)|format_currency }})
         </span>
         <div class="clearfix"></div>
         <p class="help-block col-sm-6 col-sm-offset-3">Change this to set an override on the application price, or leave

--- a/uber/templates/art_show_admin/index.html
+++ b/uber/templates/art_show_admin/index.html
@@ -46,7 +46,7 @@
         <td>{{ app.tables }}</td>
         <td>{{ app.panels_ad }}</td>
         <td>{{ app.tables_ad }}</td>
-        <td>${{ app.potential_cost }}</td>
+        <td>{{ app.potential_cost|format_currency }}</td>
         <td>{{ app.admin_notes }}</td>
     </tr>
 {% endfor %}

--- a/uber/templates/art_show_admin/pieces_bought.html
+++ b/uber/templates/art_show_admin/pieces_bought.html
@@ -109,7 +109,7 @@ Invoice #{{ receipt.invoice_num }}
           <input type="hidden" name="id" value="{{ receipt.id }}" />
           <input type="hidden" name="type" value="{{ c.CASH }}" />
           <div class="input-group">
-            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.owed / 100) }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ (receipt.owed / 100)|format_currency }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Cash Payment</button>
         </form>
@@ -117,7 +117,7 @@ Invoice #{{ receipt.invoice_num }}
       <tr><td colspan="8" class="text-right">
       <div class="form form-inline">
           <div class="input-group">
-            <span class="input-group-addon">$</span><input type="text" class="form-control" id="stripe_amount" placeholder="{{ '%0.2f' % (receipt.owed / 100) }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" id="stripe_amount" placeholder="{{ (receipt.owed / 100)format_currency }}" />
           </div>
           {{ stripe_form('purchases_charge', receipt.attendee, receipt_id=receipt.id) }}
       </div>
@@ -128,7 +128,7 @@ Invoice #{{ receipt.invoice_num }}
           <input type="hidden" name="id" value="{{ receipt.id }}" />
           <input type="hidden" name="type" value="{{ c.REFUND }}" />
           <div class="input-group">
-            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ '%0.2f' % (receipt.paid / 100) }}" />
+            <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount" placeholder="{{ (receipt.paid / 100)format_currency }}" />
           </div>
           <button type="submit" class="btn btn-success">Record Refund</button>
         </form>

--- a/uber/templates/art_show_admin/pieces_bought.html
+++ b/uber/templates/art_show_admin/pieces_bought.html
@@ -92,18 +92,18 @@ Invoice #{{ receipt.invoice_num }}
         <td> {{ piece.type_label }}
           {% if piece.print_run_num and piece.type == c.PRINT %}({{ piece.print_run_num }} of {{ piece.print_run_total }}){% endif %}
         </td>
-        <td class="text-right"> ${{ '%0.2f' % piece.sale_price }}
+        <td class="text-right"> {{ piece.sale_price|format_currency }}
         </td>
       </tr>
       {% endfor %}
       {% if receipt.pieces %}
-      <tr><td colspan="8" class="text-right">Subtotal: ${{ '%0.2f' % (receipt.subtotal / 100) }}</td></tr>
-      <tr><td colspan="8" class="text-right">Sales Tax ({{ c.SALES_TAX / 100 }}%): ${{ '%0.2f' % (receipt.tax / 100) }}</td></tr>
-      <tr><td colspan="8" class="text-right">Total Cost: ${{ '%0.2f' % (receipt.total / 100) }}</td></tr>
-      <tr><td colspan="8" class="text-right">Total Paid: ${{ '%0.2f' % (receipt.paid / 100) }}</td></tr>
+      <tr><td colspan="8" class="text-right">Subtotal: {{ (receipt.subtotal / 100)|format_currency }}</td></tr>
+      <tr><td colspan="8" class="text-right">Sales Tax ({{ c.SALES_TAX / 100 }}%): {{ (receipt.tax / 100)|format_currency }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Cost: {{ (receipt.total / 100)|format_currency }}</td></tr>
+      <tr><td colspan="8" class="text-right">Total Paid: {{ (receipt.paid / 100)|format_currency }}</td></tr>
       <tr><td colspan="8"></td></tr>
       {% if receipt.owed and receipt_open %}
-      <tr><td colspan="8" class="text-right">Owed: ${{ '%0.2f' % (receipt.owed / 100) }}</td></tr>
+      <tr><td colspan="8" class="text-right">Owed: {{ (receipt.owed / 100)|format_currency }}</td></tr>
       <tr><td colspan="8" class="text-right">
         <form role="form" method="post" class="form form-inline" action="record_payment">
           <input type="hidden" name="id" value="{{ receipt.id }}" />
@@ -144,7 +144,7 @@ Invoice #{{ receipt.invoice_num }}
           Refund of
           {%- else -%}
           {{ payment.type_label }} payment of
-          {% endif %} ${{ '%0.2f' % (payment.amount / 100) }}
+          {% endif %} {{ (payment.amount / 100)|format_currency }}
           {%- endset -%}
           {{ payment_desc }} on {{ payment.when_local|datetime("%-I:%M%p")|lower }} {{ payment.when_local|datetime("%a") }}
           &nbsp;

--- a/uber/templates/art_show_admin/sales_charge_form.html
+++ b/uber/templates/art_show_admin/sales_charge_form.html
@@ -19,7 +19,7 @@
 </script>
 
 {% if charge %}
-    <h2>${{ amount }}: {{ description }}</h2>
+    <h2>{{ amount|format_currency }}: {{ description }}</h2>
     <div class="center">
         {{ stripe_form('sales_charge',None,amount=amount,description=description) }}
         {% if sale_id %}<a href="#" onClick="undoSale('{{ sale_id }}'); return false">Undo</a>{% endif %}

--- a/uber/templates/art_show_admin/sales_search.html
+++ b/uber/templates/art_show_admin/sales_search.html
@@ -75,7 +75,7 @@
       </td>
       {% if c.PREASSIGNED_BADGE_TYPES %}<td>{{ attendee.badge_printed_name }}</td>{% endif %}
       {% if c.NUMBERED_BADGES %}<td>{{ attendee.badge_num }}</td>{% endif %}
-      <td>{{ '$%0.2f' % (attendee.art_show_receipt.owed / 100) if attendee.art_show_receipt else 'N/A' }}</td>
+      <td>{{ (attendee.art_show_receipt.owed / 100)|format_currency if attendee.art_show_receipt else 'N/A' }}</td>
       <td>{{ attendee.art_show_receipt.pieces|length }}</td>
       <td><a class="btn btn-primary" target="_sale" href="pieces_bought?id={{ attendee.id }}">
         {% if attendee.art_show_receipt and attendee.art_show_receipt.pieces %}Process Sale{% else %}Quick Sale{% endif %}</a></td>

--- a/uber/templates/art_show_applications/art_show_form.html
+++ b/uber/templates/art_show_applications/art_show_form.html
@@ -36,7 +36,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
   {% endif %}
   {% if not readonly and not admin_area %}
   <div class="clearfix"></div>
-  <p class="help-block col-sm-6 col-sm-offset-3">Mailing your art to the show incurs a fee of ${{ c.ART_MAILING_FEE }}.</p>
+  <p class="help-block col-sm-6 col-sm-offset-3">Mailing your art to the show incurs a fee of {{ c.ART_MAILING_FEE|format_currency }}.</p>
   {% endif %}
 </div>
 
@@ -72,7 +72,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
     {% else %}
       <select class="form-control" name="panels">
         {{ int_options(0, max_panels, app.panels) }}
-      </select>(${{ c.COST_PER_PANEL }} per panel)
+      </select>({{ c.COST_PER_PANEL|format_currency }} per panel)
     {% endif %}
     </div>
 </div>
@@ -88,7 +88,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
     {% else %}
       <select class="form-control" name="tables">
         {{ int_options(0, max_tables, app.tables) }}
-      </select>(${{ c.COST_PER_TABLE }} per table section)
+      </select>({{ c.COST_PER_TABLE|format_currency }} per table section)
     {% endif %}
     </div>
 </div>
@@ -104,7 +104,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
     {% else %}
       <select class="form-control" name="panels_ad">
         {{ int_options(0, max_panels, app.panels_ad) }}
-      </select>{% if not no_help_text %}(${{ c.COST_PER_PANEL }} per panel){% endif %}
+      </select>{% if not no_help_text %}({{ c.COST_PER_PANEL|format_currency }} per panel){% endif %}
       {% endif %}
     </div>
 </div>
@@ -120,7 +120,7 @@ placeholder=app.attendee.full_name, is_readonly=readonly) }}
     {% else %}
       <select class="form-control" name="tables_ad">
         {{ int_options(0, max_tables, app.tables_ad) }}
-      </select>{% if not no_help_text %}(${{ c.COST_PER_TABLE }} per table section){% endif %}
+      </select>{% if not no_help_text %}({{ c.COST_PER_TABLE|format_currency }} per table section){% endif %}
     {% endif %}
     </div>
 </div>

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -10,7 +10,7 @@
       {% if app.status in [c.APPROVED, c.PAID] %}
       {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.is_unpaid %}
-          In order to complete your application, please pay ${{ '%0.2f' % app.attendee.amount_unpaid }} using the button below.
+          In order to complete your application, please pay {{ app.attendee.amount_unpaid|format_currency }} using the button below.
           {% if app.attendee.badge_cost %}This total includes the cost of your badge, if you have not paid for it
           already.{% endif %}<br/><br/>
           <div style="text-align:center">

--- a/uber/templates/art_show_common/print_macros.html
+++ b/uber/templates/art_show_common/print_macros.html
@@ -28,23 +28,23 @@
     </td>
     <td> {{ piece.media }} </td>
     <td> {{ piece.app.display_name }} </td>
-    <td> ${{ '%0.2f' % piece.sale_price }}
+    <td> {{ piece.sale_price|format_currency }}
     </td>
   </tr>
   {% endfor %}
   <tr><td colspan="6"></td></tr>
-  <tr><td colspan="4"></td><td><strong>TOTAL Pretax</strong></td><td>${{ '%0.2f' % (receipt.subtotal / 100) }}</td></tr>
-  <tr><td colspan="4"></td><td><strong>Tax</strong></td><td>${{ '%0.2f' % (receipt.tax / 100) }}</td></tr>
-  <tr><td colspan="4"></td><td><strong>Grand Total</strong></td><td>${{ '%0.2f' % (receipt.total / 100) }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>TOTAL Pretax</strong></td><td>{{ (receipt.subtotal / 100)|format_currency }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Tax</strong></td><td>{{ (receipt.tax / 100)|format_currency }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Grand Total</strong></td><td>{{ (receipt.total / 100)|format_currency }}</td></tr>
   <tr></tr>
   {% for payment in receipt.stripe_payments %}
   <tr>
-    <td colspan="4"></td><td><strong>Total Card {{ loop.index }}</strong></td><td>${{ '%0.2f' % (payment.amount / 100) }}</td>
+    <td colspan="4"></td><td><strong>Total Card {{ loop.index }}</strong></td><td>{{ (payment.amount / 100)|format_currency }}</td>
   </tr>
   {% endfor %}
-  <tr><td colspan="4"></td><td><strong>Total Paid Credit</strong></td><td>${{ '%0.2f' % (receipt.stripe_total / 100) }}</td></tr>
-  <tr><td colspan="4"></td><td><strong>Total Paid Cash</strong></td><td>${{ '%0.2f' % (receipt.cash_total / 100) }}</td></tr>
-  <tr><td colspan="4"></td><td><strong>Amount Due:</strong></td><td>${{ '%0.2f' % (receipt.owed / 100) }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Total Paid Credit</strong></td><td>{{ (receipt.stripe_total / 100)|format_currency }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Total Paid Cash</strong></td><td>{{ (receipt.cash_total / 100)|format_currency }}</td></tr>
+  <tr><td colspan="4"></td><td><strong>Amount Due:</strong></td><td>{{ (receipt.owed / 100)|format_currency }}</td></tr>
 </table>
 {%- endmacro -%}
 
@@ -77,37 +77,37 @@
     <td> {{ piece.artist_and_piece_id }} </td>
     <td> {{ piece.name|wordwrap(25, wrapstring="<br />"|safe) }} </td>
     <td> {% if piece.voice_auctioned %}Auction{% elif piece.winning_bid %}Bid Sheet{% elif piece.valid_quick_sale %}QuickSale{% endif %} </td>
-    <td> ${{ piece.opening_bid }} </td>
-    <td> ${{ '%0.2f' % piece.sale_price }} </td>
+    <td> {{ piece.opening_bid|format_currency }} </td>
+    <td> {{ piece.sale_price|format_currency }} </td>
   </tr>
   {% endif %}
   {% endfor %}
   <tr><td colspan="5"></td></tr>
-  <tr><td colspan="4"><strong>Total Payment from Bids</strong></td><td>${{ '%0.2f' % (app.total_sales / 100) }}</td></tr>
+  <tr><td colspan="4"><strong>Total Payment from Bids</strong></td><td>{{ (app.total_sales / 100)|format_currency }}</td></tr>
 </table>
 <table class="table table-bordered" style="margin: 20px; width: calc(100% - 40px);">
   <tr><td width="25%"><strong>Fees</strong></td></tr>
   <tr>
     <td>Panels</td><td>{{ app.panels + app.panels_ad }}</td>
-    <td>Panel Cost</td><td>${{ c.COST_PER_PANEL }}</td>
-    <td>Total Panel Fee</td><td>${{ '%0.2f' % ((app.panels + app.panels_ad) * c.COST_PER_PANEL) }}</td>
+    <td>Panel Cost</td><td>{{ c.COST_PER_PANEL|format_currency }}</td>
+    <td>Total Panel Fee</td><td>{{ ((app.panels + app.panels_ad) * c.COST_PER_PANEL)|format_currency }}</td>
   </tr>
   <tr>
     <td>Tables</td><td>{{ app.tables + app.tables_ad }}</td>
-    <td>Table Cost</td><td>${{ c.COST_PER_TABLE }}</td>
-    <td>Total Table Fee</td><td>${{ '%0.2f' % ((app.tables + app.tables_ad) * c.COST_PER_TABLE) }}</td>
+    <td>Table Cost</td><td>{{ c.COST_PER_TABLE|format_currency }}</td>
+    <td>Total Table Fee</td><td>{{ ((app.tables + app.tables_ad) * c.COST_PER_TABLE)|format_currency }}</td>
   </tr>
-  {% if app.delivery_method == c.BY_MAIL %}<tr><td colspan="4"></td><td>Total Mail-In Fee</td><td>${{ '%0.2f' % c.ART_MAILING_FEE }}</td></tr>{% endif %}
-  <tr><td colspan="4"></td><td><strong>Total Fees</strong></td><td>${{ '%0.2f' % app.total_cost }}</td></tr>
-  <tr><td colspan="4"></td><td>Prepaid</td><td>${{ '%0.2f' % app.amount_paid }}</td></tr>
+  {% if app.delivery_method == c.BY_MAIL %}<tr><td colspan="4"></td><td>Total Mail-In Fee</td><td>{{ c.ART_MAILING_FEE|format_currency }}</td></tr>{% endif %}
+  <tr><td colspan="4"></td><td><strong>Total Fees</strong></td><td>{{ app.total_cost|format_currency }}</td></tr>
+  <tr><td colspan="4"></td><td>Prepaid</td><td>{{ app.amount_paid|format_currency }}</td></tr>
 </table>
 <table class="table table-bordered" style="margin: 20px; width: calc(100% - 40px);">
   <tr>
     <td width="25%"><strong>Commission Rate</strong></td><td>{{ c.COMMISSION_PCT / 100 }}%</td>
-    <td><strong>Commission</strong></td><td>${{ '%0.2f' % (app.commission / 100) }}</td>
+    <td><strong>Commission</strong></td><td>{{ (app.commission / 100)|format_currency }}</td>
   </tr>
   <tr><td><strong>Name on Check</strong></td><td>{{ app.check_payable or app.attendee.legal_first_name ~ " " ~ app.attendee.legal_last_name }}</td></tr>
-  <tr><td><strong>Check Total</strong></td><td>${{ '%0.2f' % (app.check_total / 100) }}</td></tr>
+  <tr><td><strong>Check Total</strong></td><td>{{ (app.check_total / 100|format_currency) }}</td></tr>
 </table>
 <div class="form-group">
   <label class="col-sm-3 control-label optional-field">Artist Signature</label>

--- a/uber/templates/art_show_reports/summary.html
+++ b/uber/templates/art_show_reports/summary.html
@@ -21,7 +21,7 @@
   </tr>
   <tr></tr>
   <tr>
-    <td colspan="2"><strong>Total Commission</strong></td><td>{{ '%0.2f' % ((general_sales_sum + mature_sales_sum) * (c.COMMISSION_PCT / 10000)) }}</td>
+    <td colspan="2"><strong>Total Commission</strong></td><td>{{ ((general_sales_sum + mature_sales_sum) * (c.COMMISSION_PCT / 10000))|format_currency }}</td>
   </tr>
   <tr>
     <td colspan="2"><strong>Commission % Charged</strong></td><td>{{ c.COMMISSION_PCT / 100 }}%</td>

--- a/uber/templates/art_show_reports/summary.html
+++ b/uber/templates/art_show_reports/summary.html
@@ -4,17 +4,17 @@
 <h3 align="center">Grand Summary Report -- {{ now|datetime("%m/%d/%Y, %-I:%M%p") }}</h3>
 <table class="table table-bordered" style="margin: 20px; width: calc(100% - 40px);">
   <tr>
-    <td colspan="2"><strong>Total Sales</strong></td><td width="75%">${{ '%0.2f' % (general_sales_sum + mature_sales_sum) }}</td>
+    <td colspan="2"><strong>Total Sales</strong></td><td width="75%">{{ (general_sales_sum + mature_sales_sum)|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>General</td><td>${{ '%0.2f' % general_sales_sum }}</td>
+    <td></td><td>General</td><td>{{ general_sales_sum|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>Mature</td><td>${{ '%0.2f' % mature_sales_sum }}</td>
+    <td></td><td>Mature</td><td>{{ mature_sales_sum|format_currency }}</td>
   </tr>
   <tr></tr>
   <tr>
-    <td colspan="2"><strong>Total Taxes</strong></td><td>${{ '%0.2f' % ((general_sales_sum + mature_sales_sum) * (c.SALES_TAX / 10000)) }}</td>
+    <td colspan="2"><strong>Total Taxes</strong></td><td>{{ ((general_sales_sum + mature_sales_sum) * (c.SALES_TAX / 10000))|format_currency }}</td>
   </tr>
   <tr>
     <td colspan="2"><strong>Tax % Charged</strong></td><td>{{ c.SALES_TAX / 100 }}%</td>
@@ -72,16 +72,16 @@
   </tr>
   <tr></tr>
   <tr>
-    <td colspan="2"><strong>Panel Fee</strong></td><td>${{ c.COST_PER_PANEL }}</td>
+    <td colspan="2"><strong>Panel Fee</strong></td><td>{{ c.COST_PER_PANEL|format_currency }}</td>
   </tr>
   <tr>
-    <td colspan="2"><strong>Total Panel Fees</strong></td><td>${{ '%0.2f' % ((general_panels_count + mature_panels_count) * c.COST_PER_PANEL) }}</td>
+    <td colspan="2"><strong>Total Panel Fees</strong></td><td>{{ ((general_panels_count + mature_panels_count) * c.COST_PER_PANEL)|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>General</td><td>${{ '%0.2f' % (general_panels_count * c.COST_PER_PANEL) }}</td>
+    <td></td><td>General</td><td>{{ (general_panels_count * c.COST_PER_PANEL)|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>Mature</td><td>${{ '%0.2f' % (mature_panels_count * c.COST_PER_PANEL) }}</td>
+    <td></td><td>Mature</td><td>{{ (mature_panels_count * c.COST_PER_PANEL)|format_currency }}</td>
   </tr>
   <tr></tr>
   <tr>
@@ -95,16 +95,16 @@
   </tr>
   <tr></tr>
   <tr>
-    <td colspan="2"><strong>Table Fee</strong></td><td>${{ c.COST_PER_TABLE }}</td>
+    <td colspan="2"><strong>Table Fee</strong></td><td>{{ c.COST_PER_TABLE|format_currency }}</td>
   </tr>
   <tr>
-    <td colspan="2"><strong>Total Table Fees</strong></td><td>${{ '%0.2f' % ((general_tables_count + mature_tables_count) * c.COST_PER_TABLE) }}</td>
+    <td colspan="2"><strong>Total Table Fees</strong></td><td>{{ ((general_tables_count + mature_tables_count) * c.COST_PER_TABLE)|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>General</td><td>${{ '%0.2f' % (general_tables_count * c.COST_PER_TABLE) }}</td>
+    <td></td><td>General</td><td>{{ (general_tables_count * c.COST_PER_TABLE)|format_currency }}</td>
   </tr>
   <tr>
-    <td></td><td>Mature</td><td>${{ '%0.2f' % (mature_tables_count * c.COST_PER_TABLE) }}</td>
+    <td></td><td>Mature</td><td>{{ (mature_tables_count * c.COST_PER_TABLE)|format_currency }}</td>
   </tr>
 </table>
 {% endblock %}

--- a/uber/templates/budget/attendee_cost_breakdown.html
+++ b/uber/templates/budget/attendee_cost_breakdown.html
@@ -19,14 +19,14 @@
         <tr>
           <td>{{ name }}</td>
           <td>{{ item[:-5]|replace('_', ' ')|title }}</td>
-          <td>${{ "{0:g}".format(attendee.purchased_items[item]) }}</td>
+          <td>{{ attendee.purchased_items[item]|format_currency }}</td>
         </tr>
       {% endfor %}
       {% if attendee.amount_unpaid %}
         <tr>
           <td>{{ name }}</td>
           <td>Amount Owed</td>
-          <td>-${{ "{0:g}".format(attendee.amount_unpaid) }}</td>
+          <td>-attendee.amount_unpaid|format_currency }}</td>
         </tr>
       {% endif %}
     {% endfor %}

--- a/uber/templates/budget/attendee_donation_breakdown.html
+++ b/uber/templates/budget/attendee_donation_breakdown.html
@@ -18,8 +18,8 @@
       <tr>
         <td>{{ attendee|form_link }}</td>
         <td>{{ attendee.email }}</td>
-        <td>${{ "{0:g}".format(attendee.extra_donation) }}</td>
-        <td>${{ "{0:g}".format(attendee.amount_extra) }}</td>
+        <td>{{ attendee.extra_donation|format_currency }}</td>
+        <td>{{ attendee.amount_extra|format_currency }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/uber/templates/budget/group_cost_breakdown.html
+++ b/uber/templates/budget/group_cost_breakdown.html
@@ -19,7 +19,7 @@
     <tr>
       <td>{{ group.name }}</td>
       <td>Total Cost</td>
-      <td>${{ group.cost }}</td>
+      <td>{{ group.cost|format_currency }}</td>
       <td>Group price set by admin and cannot be itemized.</td>
     </tr>
     {% elif group.tables %}
@@ -33,7 +33,7 @@
       <tr>
         <td>{{ group.name }}</td>
         <td>{{ desc }}</td>
-        <td>${{ "{0:g}".format(cost) }}</td>
+        <td>{{ cost|format_currency }}</td>
         <td></td>
       </tr>
       {% endfor %}
@@ -42,7 +42,7 @@
     <tr>
         <td>{{ group.name }}</td>
         <td>Amount Owed</td>
-        <td>-${{ "{0:g}".format(group.amount_unpaid) }}</td>
+        <td>-{{ group.amount_unpaid|format_currency }}</td>
       </tr>
     {% endif %}
     {% endfor %}

--- a/uber/templates/budget/index.html
+++ b/uber/templates/budget/index.html
@@ -10,7 +10,7 @@
 </style>
 
 <div class="jumbotron">
-    <h1 class="text-center">(${{ '%0.2f' % (total / 100) }} total)</h1>
+    <h1 class="text-center">({{ (total / 100)|format_currency }} total)</h1>
 </div>
 
 <div class="panel panel-default">
@@ -29,7 +29,7 @@
       <tr>
         <td>{{ item.attendee|form_link }}</td>
         <td>{{ item.item_type_label }}</td>
-        <td>{{ '-' if item.txn_type == c.REFUND else '' }}${{ '%0.2f' % (item.amount / 100) }}</td>
+        <td>{{ '-' if item.txn_type == c.REFUND else '' }}{{ (item.amount / 100)|format_currency }}</td>
         <td>{{ item.desc }}</td>
       </tr>
     {% endfor %}
@@ -46,7 +46,7 @@
     <tbody>
     {% for sale in sales %}
       <tr>
-        <td>${{ '%0.2f' % sale.cash }}</td>
+        <td>{{ sale.cash|format_currency }}</td>
         <td>{{ sale.what }}</td>
       </tr>
     {% endfor %}
@@ -63,7 +63,7 @@
     <tbody>
     {% for charge in arbitrary_charges %}
       <tr>
-        <td>${{ '%0.2f' % charge.amount }}</td>
+        <td>{{ charge.amount|format_currency }}</td>
         <td>{{ charge.what }}</td>
       </tr>
     {% endfor %}

--- a/uber/templates/budget/mpoints.html
+++ b/uber/templates/budget/mpoints.html
@@ -12,7 +12,7 @@
 </tr>
 {% for total,group,mpus in all %}
     <tr bgcolor="{{ loop.cycle('#ffffff', '#eeeeee') }}">
-        <td>${{ '%0.2f' % total }}</td>
+        <td>{{ total|format_currency }}</td>
         <td>
             {% if group %}
                 <a href="../group_admin/form?id={{ group.id }}">{{ group.name }}</a>
@@ -23,7 +23,7 @@
             <ul>
                 {% for mpu in mpus %}
                     <li>
-                        ${{ '%0.2f' % mpu.amount }} from
+                        {{ mpu.amount|format_currency }} from
                         {% if mpu.attendee %}
                             <a href="#attendee_form?id={{ mpu.attendee.id }}">{{ mpu.attendee.full_name }}</a>
                         {% else %}

--- a/uber/templates/dealer_admin/waitlist.html
+++ b/uber/templates/dealer_admin/waitlist.html
@@ -74,9 +74,9 @@
         </td>
         <td data-order="{{ group.badges_purchased }}" data-search="{{ group.badges_purchased }}"> {{ group.badges_purchased }} / {{ group.badges }} </td>
         <td>{{ group.tables }}</td>
-        <td>${{ '%0.2f' % group.cost }}</td>
-        <td>${{ '%0.2f' % group.amount_unpaid }}</td>
-        <td>${{ '%0.2f' % (group.amount_paid / 100) }}</td>
+        <td>{{ group.cost|format_currency }}</td>
+        <td>{{ (group.amount_unpaid / 100)|format_currency }}</td>
+        <td>{{ (group.amount_paid / 100)|format_currency }}</td>
         <td>{{ group.admin_notes }}</td>
     </tr>
 {% endfor %}

--- a/uber/templates/emails/art_show/appchange_notification.html
+++ b/uber/templates/emails/art_show/appchange_notification.html
@@ -16,11 +16,11 @@ the changes.
     {% if app.hotel_name %}<li><strong>Room Number</strong>: {{ app.hotel_room_num }}</li>{% endif %}
     {% endif %}
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
-    <li><strong>General Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li><strong>General Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
-    <li><strong>Mature Panels</strong>: {{ app.panels_ad }} mature panels (${{ app.panels_ad_cost }}) </li>
-    <li><strong>Mature Table Sections</strong>: {{ app.tables_ad }} mature table sections (${{ app.tables_ad_cost }}) </li>
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}{% if app.mailing_fee %} (including ${{ app.mailing_fee }} mailing fee){% endif %}</li>
+    <li><strong>General Panels</strong>: {{ app.panels }} panels ({{ app.panels_cost|format_currency }}) </li>
+    <li><strong>General Table Sections</strong>: {{ app.tables }} table sections ({{ app.tables_cost|format_currency }}) </li>
+    <li><strong>Mature Panels</strong>: {{ app.panels_ad }} mature panels ({{ app.panels_ad_cost|format_currency }}) </li>
+    <li><strong>Mature Table Sections</strong>: {{ app.tables_ad }} mature table sections ({{ app.tables_ad_cost|format_currency }}) </li>
+    <li><strong>Total Price</strong>: {{ app.potential_cost|format_currency }}{% if app.mailing_fee %} (including {{ app.mailing_fee|format_currency }} mailing fee){% endif %}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}
     {% if app.attendee.badge_status == c.NOT_ATTENDING %}<li>You will not be attending {{ c.EVENT_NAME }} and thus will

--- a/uber/templates/emails/art_show/application.html
+++ b/uber/templates/emails/art_show/application.html
@@ -8,11 +8,11 @@ this coming {{ event_dates() }}. Below is a copy of your application. You may
 
 <ul>
     {% if app.artist_name %}<li><strong>Artist Name</strong>: {{ app.artist_name }}</li>{% endif %}
-    <li><strong>General Panels</strong>: {{ app.panels }} panels (${{ app.panels_cost }}) </li>
-    <li><strong>General Table Sections</strong>: {{ app.tables }} table sections (${{ app.tables_cost }}) </li>
-    <li><strong>Mature Panels</strong>: {{ app.panels_ad }} mature panels (${{ app.panels_ad_cost }}) </li>
-    <li><strong>Mature Table Sections</strong>: {{ app.tables_ad }} mature table sections (${{ app.tables_ad_cost }}) </li>
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}{% if app.mailing_fee %} (including ${{ app.mailing_fee }} mailing fee){% endif %}</li>
+    <li><strong>General Panels</strong>: {{ app.panels }} panels ({{ app.panels_cost|format_currency }}) </li>
+    <li><strong>General Table Sections</strong>: {{ app.tables }} table sections ({{ app.tables_cost|format_currency }}) </li>
+    <li><strong>Mature Panels</strong>: {{ app.panels_ad }} mature panels ({{ app.panels_ad_cost|format_currency }}) </li>
+    <li><strong>Mature Table Sections</strong>: {{ app.tables_ad }} mature table sections ({{ app.tables_ad_cost|format_currency }}) </li>
+    <li><strong>Total Price</strong>: {{ app.potential_cost|format_currency }}{% if app.mailing_fee %} (including {{ app.mailing_fee|format_currency }} mailing fee){% endif %}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}
     {% if app.attendee.badge_status == c.NOT_ATTENDING %}<li>You will not be attending {{ c.EVENT_NAME }} and thus will

--- a/uber/templates/emails/art_show/approved.html
+++ b/uber/templates/emails/art_show/approved.html
@@ -28,10 +28,10 @@ filled by another applicant.{% endif %}
 
 This registration includes:
 <ul>
-    <li> {{ app.panels }} general panels (${{ app.panels_cost }}) </li>
-    <li> {{ app.tables }} general table sections (${{ app.tables_cost }}) </li>
-    <li> {{ app.panels_ad }} mature panels (${{ app.panels_ad_cost }}) </li>
-    <li> {{ app.tables_ad }} mature table sections (${{ app.tables_ad_cost }}) </li>
+    <li> {{ app.panels }} general panels ({{ app.panels_cost|format_currency }}) </li>
+    <li> {{ app.tables }} general table sections ({{ app.tables_cost|format_currency }}) </li>
+    <li> {{ app.panels_ad }} mature panels ({{ app.panels_ad_cost|format_currency }}) </li>
+    <li> {{ app.tables_ad }} mature table sections ({{ app.tables_ad_cost|format_currency }}) </li>
 </ul>
 
 <br/>You can always review the {{ c.EVENT_NAME }} Art Show rules

--- a/uber/templates/emails/art_show/payment_confirmation.txt
+++ b/uber/templates/emails/art_show/payment_confirmation.txt
@@ -1,5 +1,5 @@
 {{ app.attendee.first_name }},
 
-Your payment of ${{ app.total_cost }} for space in the {{ c.EVENT_NAME }} Art Show has been received. You will have {{ app.panels }} general panel{{ app.panels|pluralize }}, {{ app.panels_ad}} adult panel{{ app.panels_ad|pluralize }}, {{ app.tables }} general table{{ app.tables|pluralize }}, and {{ app.tables_ad}} adult table{{ app.tables_ad|pluralize }} available to display your art. {% if app.delivery_method == c.BY_MAIL %} Your mail-in fee was ${{ c.ART_MAILING_FEE }}. {% endif %}The Art Show director will continue to be in touch with you to keep you informed of Art Show rules and procedures.
+Your payment of {{ app.total_cost|format_currency }} for space in the {{ c.EVENT_NAME }} Art Show has been received. You will have {{ app.panels }} general panel{{ app.panels|pluralize }}, {{ app.panels_ad}} adult panel{{ app.panels_ad|pluralize }}, {{ app.tables }} general table{{ app.tables|pluralize }}, and {{ app.tables_ad}} adult table{{ app.tables_ad|pluralize }} available to display your art. {% if app.delivery_method == c.BY_MAIL %} Your mail-in fee was {{ c.ART_MAILING_FEE|format_currency }}. {% endif %}The Art Show director will continue to be in touch with you to keep you informed of Art Show rules and procedures.
 
 {{ c.ART_SHOW_SIGNATURE }}

--- a/uber/templates/emails/art_show/payment_reminder.txt
+++ b/uber/templates/emails/art_show/payment_reminder.txt
@@ -4,7 +4,7 @@ Thanks again for applying to present in the Art Show for this year's {{ c.EVENT_
 Art Show application is still unpaid, and if we do not receive payment by {{ c.ART_SHOW_PAYMENT_DUE|datetime_local }} then it will be
 deleted.
 
-You can use the credit card button on your application's page to pay the ${{ app.attendee.amount_unpaid }} that you owe:
+You can use the credit card button on your application's page to pay the {{ app.attendee.amount_unpaid|format_currency }} that you owe:
 {{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}
 
 {{ c.ART_SHOW_EMAIL_SIGNATURE }}

--- a/uber/templates/emails/dealers/application.html
+++ b/uber/templates/emails/dealers/application.html
@@ -8,9 +8,9 @@ this coming {{ event_dates() }}. Below is a copy of your application. You may
 <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>.
 <ul>
     <li><strong>Table Name</strong>: {{ group.name }}</li>
-    <li><strong>Tables</strong>: {{ group.tables }} table{{ group.tables|pluralize }} (${{ '%0.2f' % group.table_cost }}) </li>
-    <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} (${{ '%0.2f' % group.badge_cost }}) </li>
-    <li><strong>Total Price</strong> ${{ '%0.2f' % group.cost }}</li>
+    <li><strong>Tables</strong>: {{ group.tables }} table{{ group.tables|pluralize }} ({{ group.table_cost|format_currency }}) </li>
+    <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.badge_cost|format_currency }}) </li>
+    <li><strong>Total Price</strong> {{ group.cost|format_currency }}</li>
     <li><strong>What do you sell?</strong> {{ group.wares }}</li>
     <li><strong>Description</strong>: {{ group.description }}</li>
     {% if group.special_needs %}<li><strong>Table Requests and Special Requests</strong>: {{ group.special_needs }}</li>{% endif %}
@@ -28,7 +28,7 @@ you will receive a waitlist or declined email.
 {% endif %}
 
 <br/><br/>{{ c.DEALER_APP_TERM|capitalize }}s automatically reserve the ability to purchase badges for you and the number of assistants on the
-application at the pre-registration price of ${{ c.BADGE_PRICE }}, if the application is not approved. PLEASE DO NOT BUY A BADGE
+application at the pre-registration price of {{ c.BADGE_PRICE|format_currency }}, if the application is not approved. PLEASE DO NOT BUY A BADGE
 IF YOU APPLIED FOR A MARKETPLACE SPOT. Your ability to purchase the badges will happen after the waitlist is exhausted if you are
 not approved to vend.
 

--- a/uber/templates/emails/dealers/approved.html
+++ b/uber/templates/emails/dealers/approved.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
 Your group ({{ group.name }}) has been approved as a {{ c.EVENT_NAME }} {{ c.DEALER_TERM }} for this coming {{ event_dates() }}!
-You can pay the ${{ '%0.2f' % group.cost }} you owe using the credit card button
+You can pay the {{ group.cost|format_currency }} you owe using the credit card button
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">on this page</a>.
 Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your application will be removed and your tables filled by another applicant.
 
@@ -17,8 +17,8 @@ Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your applic
 
 This registration includes:
 <ul>
-    <li> {{ group.tables }} table{{ group.tables|pluralize }} (${{ '%0.2f' % group.table_cost }}) </li>
-    <li> {{ group.badges }} badge{{ group.badges|pluralize }} (${{ '%0.2f' % group.badge_cost }}) </li>
+    <li> {{ group.tables }} table{{ group.tables|pluralize }} ({{ group.table_cost|format_currency }}) </li>
+    <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.badge_cost|format_currency }}) </li>
 </ul>
 
 <br/> <u>{{ c.DEALER_LOC_TERM|title }} Rules and Information</u>

--- a/uber/templates/emails/dealers/payment_confirmation.html
+++ b/uber/templates/emails/dealers/payment_confirmation.html
@@ -1,6 +1,6 @@
 {{ group.leader.first_name }},
 
-Your group ({{ group.name }}) has been preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of ${{ '%0.2f' % (attendee.amount_paid / 100) }} has been received. Your group will have {{ group.tables }} Marketplace table{{ group.table|pluralize }}. The Marketplace coordinator will continue to be in touch with you to keep you informed of Marketplace rules and procedures.
+Your group ({{ group.name }}) has been preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of {{ (attendee.amount_paid / 100)|format_currency }} has been received. Your group will have {{ group.tables }} Marketplace table{{ group.table|pluralize }}. The Marketplace coordinator will continue to be in touch with you to keep you informed of Marketplace rules and procedures.
 
 {% if group.unassigned_badges %}
     <br/> <br/>

--- a/uber/templates/emails/dealers/payment_notification.txt
+++ b/uber/templates/emails/dealers/payment_notification.txt
@@ -1,2 +1,2 @@
-"{{ group.name }}" has just paid ${{ '%0.2f' % (group.amount_paid / 100) }} for their {{ c.DEALER_REG_TERM }}.
+"{{ group.name }}" has just paid {{ (group.amount_paid / 100)|format_currency }} for their {{ c.DEALER_REG_TERM }}.
 {{ c.URL_BASE }}/group_admin/form?id={{ group.id }}

--- a/uber/templates/emails/dealers/payment_reminder.txt
+++ b/uber/templates/emails/dealers/payment_reminder.txt
@@ -2,6 +2,6 @@
 
 Thanks again for registering as a {{ c.DEALER_TERM }} for this year's {{ c.EVENT_NAME }}.  Our records indicate that your Dealer registration ({{ group.name }}) is still unpaid, and if we do not receive payment by {{ c.DEALER_PAYMENT_DUE|datetime_local }} then it will be deleted.
 
-You can use the credit card button on your group's page to pay the ${{ '%0.2f' % group.amount_unpaid }} that you owe: {{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}
+You can use the credit card button on your group's page to pay the {{ group.amount_unpaid|format_currency }} that you owe: {{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}
 
 {{ c.MARKETPLACE_EMAIL_SIGNATURE }}

--- a/uber/templates/emails/marketplace/appchange_notification.html
+++ b/uber/templates/emails/marketplace/appchange_notification.html
@@ -10,7 +10,7 @@ the changes.
 
 <ul>
     {% if app.business_name %}<li><strong>Business Name</strong>: {{ app.business_name }}</li>{% endif %}
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
+    <li><strong>Total Price</strong>: {{ app.potential_cost|format_currency }}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     <li><strong>Categories</strong>: {{ app.categories_labels|join(', ') }}{% if app.categories_text %}{% if app.categories_labels%} / {% endif %}Other: {{ app.categories_text }}{% endif %}</li>
     {% if app.tax_number %}<li><strong>Illinois Business Tax Number</strong>: {{ app.tax_number }}</li>{% endif %}

--- a/uber/templates/emails/marketplace/application.html
+++ b/uber/templates/emails/marketplace/application.html
@@ -8,14 +8,14 @@ this coming {{ event_dates() }}. Below is a copy of your application. You may
 
 <ul>
     {% if app.business_name %}<li><strong>Business Name</strong>: {{ app.business_name }}</li>{% endif %}
-    <li><strong>Total Price</strong>: ${{ app.potential_cost }}</li>
+    <li><strong>Total Price</strong>: {{ app.potential_cost|format_currency }}</li>
     <li><strong>Description</strong>: {{ app.description }}</li>
     <li><strong>Categories</strong>: {{ app.categories_labels|join(', ') }}{% if app.categories_text %}{% if app.categories_labels%} / {% endif %}Other: {{ app.categories_text }}{% endif %}</li>
     {% if app.tax_number %}<li><strong>Illinois Business Tax Number</strong>: {{ app.tax_number }}</li>{% endif %}
     {% if app.special_needs %}<li><strong>Special Requests</strong>: {{ app.special_needs }}</li>{% endif %}
 </ul>
 
-Should your application be approved, you will be required to pay a ${{ app.potential_cost }} fee to complete your reservation.
+Should your application be approved, you will be required to pay a {{ app.potential_cost|format_currency }} fee to complete your reservation.
 {% if app.attendee.badge_status == c.NEW_STATUS %}
 You MUST complete your {{ c.EVENT_NAME }} registration before you will be able to pay for your marketplace space. You
 may complete your registration

--- a/uber/templates/emails/marketplace/approved.html
+++ b/uber/templates/emails/marketplace/approved.html
@@ -14,7 +14,7 @@ You have been approved for a space in the Marketplace for {{ c.EVENT_NAME }} thi
       be in the marketplace
     {% endif %}
   {% elif app.amount_unpaid or app.attendee.amount_unpaid %}
-    pay the ${{ app.amount_unpaid }} marketplace fee <a href="{{ c.URL_BASE }}/marketplace/edit?id={{ app.id }}">here</a>
+    pay the {{ app.amount_unpaid|format_currency }} marketplace fee <a href="{{ c.URL_BASE }}/marketplace/edit?id={{ app.id }}">here</a>
   {% endif %}.
 {% endif %}
 {% if app.attendee.amount_unpaid %}Payment is expected by {{ c.MARKETPLACE_PAYMENT_DUE|datetime_local }} or your application may be removed and your space

--- a/uber/templates/emails/marketplace/payment_confirmation.txt
+++ b/uber/templates/emails/marketplace/payment_confirmation.txt
@@ -1,5 +1,5 @@
 {{ app.attendee.first_name }},
 
-Your payment of ${{ app.total_cost }} for space in the {{ c.EVENT_NAME }} Marketplace has been received. The Marketplace director will continue to be in touch with you to keep you informed of Marketplace rules and procedures.
+Your payment of {{ app.total_cost|format_currency }} for space in the {{ c.EVENT_NAME }} Marketplace has been received. The Marketplace director will continue to be in touch with you to keep you informed of Marketplace rules and procedures.
 
 {{ c.MARKETPLACE_APP_SIGNATURE }}

--- a/uber/templates/emails/marketplace/payment_reminder.txt
+++ b/uber/templates/emails/marketplace/payment_reminder.txt
@@ -4,7 +4,7 @@ Thanks again for applying to present in the Marketplace for this year's {{ c.EVE
 Marketplace application is still unpaid, and if we do not receive payment by {{ c.MARKETPLACE_PAYMENT_DUE|datetime_local }} then it will be
 deleted.
 
-You can use the credit card button on your application's page to pay the ${{ app.attendee.amount_unpaid }} that you owe:
+You can use the credit card button on your application's page to pay the {{ app.attendee.amount_unpaid|format_currency }} that you owe:
 {{ c.URL_BASE }}/marketplace/edit?id={{ app.id }}
 
 {{ c.MARKETPLACE_APP_SIGNATURE }}

--- a/uber/templates/emails/placeholders/regular.txt
+++ b/uber/templates/emails/placeholders/regular.txt
@@ -1,6 +1,6 @@
 {% if attendee.first_name %}{{ attendee.first_name }},
 
-{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of ${{ '%0.2f' % attendee.amount_unpaid }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
+{% endif %}You've been added to the {{ c.EVENT_NAME }} registration database, but we don't have all of your personal information{% if attendee.amount_unpaid %} and you have not yet paid your outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% endif %}.  To ensure that you can pick up your badge with no hassles at our registration desk, please fill out the rest of your info{% if attendee.amount_unpaid %} and pay{% endif %} at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }} and then simply bring a photo ID to {{ c.EVENT_NAME }}.
 
 Please let us know if you have any questions.
 

--- a/uber/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/uber/templates/emails/reg_workflow/attendee_confirmation.html
@@ -14,7 +14,7 @@ You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME }} this co
 {% elif attendee.paid == c.NEED_NOT_PAY %}
     by claiming your free badge.
 {% else %}
-    and your payment of ${{ '%0.2f' % (attendee.amount_paid / 100) }} has been received.
+    and your payment of {{ (attendee.amount_paid / 100)|format_currency }} has been received.
 {% endif %}
 Your registration confirmation number is {{ attendee.id }}, and you can update your information or kick in
 {% if attendee.amount_extra %}
@@ -37,7 +37,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 
 {% if attendee.amount_extra %}
     <br/> <br/>
-    Your additional contribution of ${{ attendee.amount_extra }} provides you with these bonus items, which may be picked up at our merch booth:
+    Your additional contribution of {{ attendee.amount_extra|format_currency }} provides you with these bonus items, which may be picked up at our merch booth:
     <ul style="margin-bottom: 0">
     {% for swag in attendee.donation_swag|list %}
         <li>{{ swag }}</li>

--- a/uber/templates/emails/reg_workflow/group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/group_confirmation.html
@@ -3,7 +3,7 @@
 <body>
 
 Your {{ group.is_dealer|yesno(c.DEALER_REG_TERM + ",group") }} ({{ group.name }}) has been preregistered for
-{{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of ${{ '%0.2f' % (group.amount_paid / 100) }} has been received.
+{{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of {{ (group.amount_paid / 100)|format_currency }} has been received.
 
 {% if group.unregistered_badges %}
     <br/> <br/>

--- a/uber/templates/emails/reg_workflow/group_donation.txt
+++ b/uber/templates/emails/reg_workflow/group_donation.txt
@@ -1,6 +1,6 @@
 {{ attendee.first_name }},
 
-Thanks so much for kicking in ${{ attendee.amount_extra }} with your {{ c.EVENT_NAME }} registration.  This provides you with these bonus items, which may be picked up at our merch booth:
+Thanks so much for kicking in {{ attendee.amount_extra|format_currency }} with your {{ c.EVENT_NAME }} registration.  This provides you with these bonus items, which may be picked up at our merch booth:
 {% for swag in attendee.donation_swag %}
 - {{ swag }}
 {% endfor %}

--- a/uber/templates/emails/reg_workflow/payment_refunded.txt
+++ b/uber/templates/emails/reg_workflow/payment_refunded.txt
@@ -1,5 +1,5 @@
 {{ attendee.first_name }},
 
-Your {{ c.EVENT_NAME_AND_YEAR }} registration has been refunded in the amount of ${{ '%0.2f' % (attendee.amount_refunded / 100) }}.  Unless you've already been told otherwise in a person, this amount will be refunded to the credit card used to pay for the registration.  You can expect the money to show up in 5-10 business days.
+Your {{ c.EVENT_NAME_AND_YEAR }} registration has been refunded in the amount of {{ (attendee.amount_refunded / 100)|format_currency }}.  Unless you've already been told otherwise in a person, this amount will be refunded to the credit card used to pay for the registration.  You can expect the money to show up in 5-10 business days.
 
 {{ c.REGDESK_EMAIL_SIGNATURE }}

--- a/uber/templates/emails/reg_workflow/promo_code_group_confirmation.html
+++ b/uber/templates/emails/reg_workflow/promo_code_group_confirmation.html
@@ -2,7 +2,7 @@
 <head></head>
 <body>
 
-You have successfully registered group "{{ group.name }}" for {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of ${{ '%0.2f' % (group.buyer.amount_paid / 100) }} has been received. Your group has {{ group.promo_codes|length|int + 1 }} badges, including your own.
+You have successfully registered group "{{ group.name }}" for {{ c.EVENT_NAME }} this coming {{ event_dates() }} and your payment of {{ (group.buyer.amount_paid / 100)|format_currency }} has been received. Your group has {{ group.promo_codes|length|int + 1 }} badges, including your own.
 
 <br/><br/>
 Group badges are allocated using promo codes: your group members will simply enter a promo code <a href="{{ c.URL_BASE }}/preregistration/">while preregistering</a> to claim a badge in your group.

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -630,7 +630,7 @@
                                               src="{{ tier.icon }}"
                                               width="50px"
                                               alt="">
-                                      + ${{ tier.price }}
+                                      + {{ tier.price|format_currency }}
                                     </span>
                     {% endif %}
                   </div>
@@ -1541,7 +1541,7 @@ $(window).on("runJavaScript", function(){
         This attendee is the buyer/group leader for <strong><a href="../registration/promo_code_group_form?id={{ group.id }}" target="_blank">{{ group.name }}</a></strong>.
       {% endfor %}
       {% if attendee.promo_code and attendee.promo_code.group %}
-        This attendee used promo code <strong>{{ attendee.promo_code.code }}</strong> to claim a ${{ '%0.2f' % attendee.promo_code.cost }} badge in promo code group <strong><a href="../registration/promo_code_group_form?id={{ attendee.promo_code.group.id }}" target="_blank">{{ attendee.promo_code_group_name }}</a></strong>.
+        This attendee used promo code <strong>{{ attendee.promo_code.code }}</strong> to claim a {{ attendee.promo_code.cost|format_currency }} badge in promo code group <strong><a href="../registration/promo_code_group_form?id={{ attendee.promo_code.group.id }}" target="_blank">{{ attendee.promo_code_group_name }}</a></strong>.
       {% endif %}
     </div>
   </div>
@@ -1647,7 +1647,7 @@ $(window).on("runJavaScript", function(){
   <label class="col-sm-3 control-label">Paid</label>
   <div class="col-sm-6">
   {% if read_only %}
-    <p class="form-control-static">This attendee's paid status is <strong>{{ attendee.paid_label }}</strong>. They have given us ${{ '%0.2f' % (attendee.amount_paid / 100) }} and been refunded ${{ '%0.2f' % (attendee.amount_refunded / 100) }}.</p>
+    <p class="form-control-static">This attendee's paid status is <strong>{{ attendee.paid_label }}</strong>. They have given us {{ (attendee.amount_paid / 100)|format_currency }} and been refunded {{ (attendee.amount_refunded / 100)|format_currency }}.</p>
     {% else %}
     <div class="form-inline">
       <select name="paid" class="form-control">
@@ -1655,11 +1655,11 @@ $(window).on("runJavaScript", function(){
       </select>
       &nbsp;&nbsp;&nbsp;
       <span id="amount_paid">
-            Paid: ${{ '%0.2f' % (attendee.amount_paid / 100) }}
+            Paid: {{ (attendee.amount_paid / 100)|format_currency }}
         </span>
       &nbsp;&nbsp;&nbsp;
       <span id="amount_refunded">
-            Refunded: ${{ '%0.2f' % (attendee.amount_refunded / 100) }}
+            Refunded: {{ (attendee.amount_refunded / 100)|format_currency }}
         </span>
       {% if not read_only and c.HAS_REG_ADMIN_ACCESS %}
         [<a href="../reg_admin/receipt_items?id={{ attendee.id }}" target="_blank">Manage Payments</a>]

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -37,14 +37,14 @@
       <br/><br/>Here is your group's cost breakdown:
       <ul>
         {% if group.auto_recalc %}
-          <li>${{ '%0.2f' % group.table_cost }} for {{ group.tables }} table{{ group.tables|pluralize }}</li>
-          <li>${{ '%0.2f' % group.badge_cost }} for {{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }}
+          <li>{{ group.table_cost|format_currency }} for {{ group.tables }} table{{ group.tables|pluralize }}</li>
+          <li>{{ group.badge_cost|format_currency }} for {{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }}
             {% if upgraded_badges %}(including {{ upgraded_badges }} upgraded badge{{ upgraded_badges|pluralize }}){% endif %}</li>
         {% else %}
-          <li>${{ '%0.2f' % group.cost }} total cost</li>
+          <li>{{ group.cost|format_currency }} total cost</li>
         {% endif %}
-        <li>${{ '%0.2f' % (group.amount_paid / 100) }} paid{% if group.amount_unpaid %} so far</li>
-          <li>${{ '%0.2f' % group.amount_unpaid }} unpaid</li>
+        <li>{{ (group.amount_paid / 100)|format_currency }} paid{% if group.amount_unpaid %} so far</li>
+          <li>{{ group.amount_unpaid|format_currency }} unpaid</li>
           </ul>
           <br/>{{ stripe_form('process_group_payment',group) }}
         {% else %}
@@ -131,11 +131,11 @@
 
 {% set post_text %}
 {% if attendee_or_group.is_dealer and not admin_area %}
-  ${{ c.DEALER_BADGE_PRICE }} per badge
+  {{ c.DEALER_BADGE_PRICE|format_currency }} per badge
 {% elif admin_area and not group.is_new %}
   [{{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }} purchased]
 {% elif not admin_area %}
-  (${{ c.GROUP_PRICE }} each)
+  ({{ c.GROUP_PRICE|format_currency }} each)
 {% endif %}
 {% endset %}
 
@@ -331,7 +331,7 @@
 <div class="form-group">
   <label class="col-sm-3 control-label">Amount Paid</label>
   <div class="col-sm-6 form-control-static">
-    ${{ '%0.2f' % (group.amount_paid / 100) }}
+    {{ (group.amount_paid / 100)|format_currency }}
   </div>
 </div>
 {% endset %}
@@ -363,7 +363,7 @@
 <div class="form-group">
   <label class="col-sm-3 control-label">Amount Refunded</label>
   <div class="col-sm-6 form-control-static">
-    ${{ '%0.2f' % (group.amount_refunded / 100) if group.amount_refunded else '0' }}
+    {{ (group.amount_refunded / 100)|format_currency if group.amount_refunded else '0' }}
   </div>
 </div>
 {% endset %}

--- a/uber/templates/group_admin/dealers.html
+++ b/uber/templates/group_admin/dealers.html
@@ -44,9 +44,9 @@
         </td>
         <td data-order="{{ group.badges_purchased }}" data-search="{{ group.badges_purchased }}"> {{ group.badges_purchased }} / {{ group.badges }} </td>
         <td>{{ group.tables }}</td>
-        <td>${{ '%0.2f' % group.cost }}</td>
-        <td>${{ '%0.2f' % group.amount_unpaid }}</td>
-        <td>${{ '%0.2f' % (group.amount_paid / 100) }}</td>
+        <td>{{ group.cost|format_currency }}</td>
+        <td>{{ group.amount_unpaid|format_currency }}</td>
+        <td>{{ (group.amount_paid / 100)|format_currency }}</td>
         <td>{{ group.admin_notes }}</td>
     </tr>
 {% endfor %}

--- a/uber/templates/guests/band_agreement.html
+++ b/uber/templates/guests/band_agreement.html
@@ -58,7 +58,7 @@
       Payment
     </h3>
     <p>
-      <strong>${{ guest.payment }}</strong> by check on site after the show.
+      <strong>{{ guest.payment|format_currency }}</strong> by check on site after the show.
     </p>
   {% endif %}
 {% endblock %}

--- a/uber/templates/guests_macros.html
+++ b/uber/templates/guests_macros.html
@@ -260,7 +260,7 @@
         </div>
         <div class="inventory-item-price data-item">
           <dt>Price</dt>
-          <dd>${{ '%0.2f' %  item.price|float }}</dd>
+          <dd>{{ item.price|format_currency }}</dd>
         </div>
         <div class="inventory-item-quantity data-item">
           <dt>Quantity</dt>

--- a/uber/templates/marketplace/edit.html
+++ b/uber/templates/marketplace/edit.html
@@ -11,7 +11,7 @@
       {% if app.status in [c.APPROVED, c.PAID] %}
       {% if app.status == c.APPROVED %}Congratulations, your application has been approved!{% endif %}
         {% if not app.incomplete_reason and app.amount_unpaid %}
-          In order to complete your application, please pay ${{ '%0.2f' % app.attendee.amount_unpaid }} using the button below.
+          In order to complete your application, please pay {{ app.attendee.amount_unpaid|format_currency }} using the button below.
           {% if payment_includes_badge %}This total includes the cost of your badge.{% endif %}<br/><br/>
           <div style="text-align:center">
               {{ stripe_form('process_marketplace_payment', app.attendee) }}

--- a/uber/templates/marketplace_admin/form.html
+++ b/uber/templates/marketplace_admin/form.html
@@ -65,7 +65,7 @@ app, c.PAGE_PATH,
           <div class="form-inline">
           <span id="amount_paid">
             <div class="input-group">
-              <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount_paid" value="{{ app.amount_paid }}" />
+              <span class="input-group-addon">$</span><input type="text" class="form-control" name="amount_paid" value="{{ app.amount_paid|format_currency }}" />
             </div>
           </span>
           </div>
@@ -93,7 +93,7 @@ app, c.PAGE_PATH,
                  value="{{ app.overridden_price if app.overridden_price != None else '' }}" />
         </div>
         <span class="col-sm-4 form-control-static">
-          (Base Price: ${{ app.base_price|default(app.potential_cost) }})
+          (Base Price: {{ app.base_price|default(app.potential_cost)|format_currency }})
         </span>
         <div class="clearfix"></div>
         <p class="help-block col-sm-6 col-sm-offset-3">Change this to set an override on the application price, or leave

--- a/uber/templates/marketplace_admin/index.html
+++ b/uber/templates/marketplace_admin/index.html
@@ -40,7 +40,7 @@
         <td>{{ app.special_needs }}</td>
         <td>{{ app.tax_number }}</td>
         <td>{{ app.admin_notes }}</td>
-        <td>${{ app.amount_paid }}</td>
+        <td>{{ app.amount_paid|format_currency }}</td>
     </tr>
 {% endfor %}
 	<caption align="bottom">

--- a/uber/templates/merch_admin/arbitrary_charge_form.html
+++ b/uber/templates/merch_admin/arbitrary_charge_form.html
@@ -11,7 +11,7 @@
 </script>
 
 {% if charge %}
-    <h2>${{ '%0.2f' % amount|float }}: {{ description }}</h2>
+    <h2>{{ amount|format_currency }}: {{ description }}</h2>
     <div class="center">
         {{ stripe_form('arbitrary_charge',None,amount=amount,description=description) }}
         {% if sale_id %}<a href="#" onClick="undoSale('{{ sale_id }}'); return false">Undo</a>{% endif %}

--- a/uber/templates/merch_reports/owed_merch.html
+++ b/uber/templates/merch_reports/owed_merch.html
@@ -23,7 +23,7 @@
         <td>{{ attendee.merch }}</td>
         <td>{{ attendee.shirt_label }}</td>
         <td>{{ attendee.badge_num }}</td>
-        <td>${{ "{0:g}".format(attendee.amount_unpaid) }}</td>
+        <td>{{ attendee.amount_unpaid|format_currency }}</td>
         <td>{{ attendee.checked_in|datetime_local }}</td>
         <td>{{ attendee.admin_notes }}</td>
     </tr>

--- a/uber/templates/model_history_base.html
+++ b/uber/templates/model_history_base.html
@@ -36,8 +36,8 @@
       {% for log in model.stripe_txn_share_logs %}
         <tr>
           <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.stripe_id }}</td>
-          <td valign="top" style="white-space:nowrap">${{ '%0.2f' % (log.share / 100) }}
-          <td valign="top" style="white-space:nowrap">${{ '%0.2f' % (log.stripe_transaction.amount / 100) }} {{ log.stripe_transaction.type_label }}</td>
+          <td valign="top" style="white-space:nowrap">{{ (log.share / 100)|format_currency }}
+          <td valign="top" style="white-space:nowrap">{{ (log.stripe_transaction.amount / 100)|format_currency }} {{ log.stripe_transaction.type_label }}</td>
           <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.when|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
           <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.who }}</td>
           <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.desc }}</td>

--- a/uber/templates/preregistration/add_group_members.html
+++ b/uber/templates/preregistration/add_group_members.html
@@ -7,7 +7,7 @@
   <div class="panel-body">
     <h2> Add Members to {{ group.name }} </h2>
 
-    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}, at a cost of ${{ '%0.2f' % (count|int * group.new_badge_cost) }}.
+    You've indicated you'd like to add {{ count }} {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}, at a cost of {{ (count|int * group.new_badge_cost)|format_currency }}.
 
     <table style="width: auto; margin: 15px auto 0;">
       <tr>

--- a/uber/templates/preregistration/add_promo_codes.html
+++ b/uber/templates/preregistration/add_promo_codes.html
@@ -7,7 +7,7 @@
     <div class="panel-body">
       <h2> Add Badge Codes to {{ group.name }} </h2>
 
-      You've indicated you'd like to add {{ count }} promo code{{ count|int|pluralize }}, at a cost of ${{ '%0.2f' % (count|int * c.GROUP_PRICE) }}.
+      You've indicated you'd like to add {{ count }} promo code{{ count|int|pluralize }}, at a cost of {{ (count|int * c.GROUP_PRICE)|format_currency }}.
       <table style="width: auto; margin: 15px auto 0;">
         <tr>
           <td>{{ stripe_form('pay_for_extra_codes',group,count=count) }}</td>

--- a/uber/templates/preregistration/attendee_donation_form.html
+++ b/uber/templates/preregistration/attendee_donation_form.html
@@ -8,7 +8,7 @@
     {% if attendee.paid == c.NOT_PAID %}
       <h2> Badge Payment for {{ attendee.full_name }} </h2>
 
-      You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of ${{ '%0.2f' % attendee.badge_cost }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|round(2) }}.
+      You've registered for {{ c.EVENT_NAME }} at a {% if attendee.overridden_price %}discounted{% endif %} price of {{ attendee.badge_cost|format_currency }}{% if attendee.amount_extra %} and you've also kicked in {{ attendee.amount_extra|format_currency }}{% endif %}; your total outstanding balance is {{ attendee.amount_unpaid|format_currency }}.
 
       <table style="width: auto; margin: 15px auto 0;">
         <tr class="stripe_form">
@@ -33,7 +33,7 @@
     {% else %}
       <h2> Extra Payment for {{ attendee.full_name }} </h2>
 
-      Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ '%0.2f' % attendee.amount_unpaid }} is outstanding) entitles you to the following:
+      Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which {{ attendee.amount_unpaid|format_currency }} is outstanding) entitles you to the following:
       <ul>
         {% for swag in attendee.donation_swag|list + attendee.addons|list %}
           <li>{{ swag }}</li>

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -43,11 +43,11 @@
 
       {% block form_top %}{% endblock %}
 
-      {% if attendee.amount_unpaid and c.HTTP_METHOD == 'GET' and 'attendee_donation_form' in attendee.payment_page %}
+      {% if not attendee.placeholder and attendee.amount_unpaid and c.HTTP_METHOD == 'GET' and 'attendee_donation_form' in attendee.payment_page %}
         <br/>
         <div class="form-group">
           <div class="col-sm-9 col-sm-offset-3 warning">
-            You currently have an outstanding balance of ${{ '%0.2f' % attendee.amount_unpaid }}{% if attendee.amount_extra %} due to having requested
+            You currently have an outstanding balance of {{ attendee.amount_unpaid|format_currency }}{% if attendee.amount_extra %} due to having requested
             registration add-ons and then not completing the payment form{% endif %}.  Please either
             <a href="attendee_donation_form?id={{ attendee.id }}">click here</a> to pay, or alter your registration below to
             eliminate whichever addons you've decided not to select.

--- a/uber/templates/preregistration/dealer_confirmation.html
+++ b/uber/templates/preregistration/dealer_confirmation.html
@@ -33,7 +33,7 @@
 
     <br/><br/>In the event we cannot accommodate your {{ c.DEALER_REG_TERM }}, you will receive an email. If your application
     is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
-    at the pre-registration price of ${{ c.BADGE_PRICE }} when the waitlist is exhausted. You will receive an email
+    at the pre-registration price of {{ c.BADGE_PRICE|format_currency }} when the waitlist is exhausted. You will receive an email
     when these badges are available for purchase.
 
     {% include "preregistration/disclaimers.html" %}

--- a/uber/templates/preregistration/duplicate.html
+++ b/uber/templates/preregistration/duplicate.html
@@ -34,7 +34,7 @@
         <br/> <br/>
         It looks like your {{ c.DEALER_REG_TERM }} application has not been approved yet. If your application
         is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
-        at the pre-registration price of ${{ '%0.2f' % attendee.badge_cost }} when the waitlist is exhausted. You will receive an email
+        at the pre-registration price of {{ attendee.badge_cost|format_currency }} when the waitlist is exhausted. You will receive an email
         when these badges are available for purchase.
     {% endif %}
 

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -141,7 +141,7 @@
                 {% elif attendee.is_transferable and attendee.total_donation %}
                   <form method="get" action="transfer_badge">
                     <input type="hidden" name="id" value="{{ attendee.id }}" />
-                    <b> Added on an extra ${{ '%0.2f' % attendee.total_donation }}! </b>
+                    <b> Added on an extra {{ attendee.total_donation|format_currency }}! </b>
                     <input type="submit" value="Transfer Registration" />
                   </form>
                 {% endif %}

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -20,7 +20,7 @@
     {% include 'confirm_tabs.html' with context %}
 
     <h2> Members of "{{ group.name }}" </h2>
-    You have bought {{ group.promo_codes|length }} promo codes for a total of ${{ '%0.2f' % group.total_cost }} (not including your badge).
+    You have bought {{ group.promo_codes|length }} promo codes for a total of {{ group.total_cost|format_currency }} (not including your badge).
     {% if group.valid_codes %}Anyone can register a badge under this group using either an unclaimed promo code below or this group's universal code, <strong>{{ group.code }}</strong>.
     {% else %}All promo codes have been claimed. Please email us at {{ c.REGDESK_EMAIL|email_to_link }} if a promo code was claimed in error.{% endif %}
     <br/><br/><strong>Here are the promo codes for your group "{{ group.name }}" and who is using them:</strong>
@@ -65,7 +65,7 @@
         <form class="form-inline" method="get" action="add_promo_codes">
           <input type="hidden" name="id" value="{{ group.id }}" />
           <p>
-            Enter the number of extra codes to purchase for <strong>${{ c.GROUP_PRICE }}</strong> per code.&nbsp;
+            Enter the number of extra codes to purchase for <strong>{{ c.GROUP_PRICE|format_currency }}</strong> per code.&nbsp;
               {%- set hours_remaining = group.hours_remaining_in_grace_period -%}
               {%- if hours_remaining > 0 -%}
                 You have {{ humanize_timedelta(hours=hours_remaining, granularity='minutes') }}

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -109,7 +109,7 @@
               {% if not attendee.badge_cost and attendee.age_discount and not attendee.promo_code_id %}
                 <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
               {% elif attendee.age_discount and attendee.age_group_conf.discount != 0 %}
-                <li>${{ attendee.age_group_conf.discount }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
+                <li>{{ attendee.age_group_conf.discount|format_currency }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>
               {% endif %}
               {% for swag in attendee.donation_swag|list + attendee.addons|list %}
                 <li>{{ swag }}</li>
@@ -125,9 +125,9 @@
           </td>
           <td>
             {% if attendee.badges %}
-              ${{ '%0.2f' % (attendee.amount_extra_unpaid + (attendee.badges|int * c.GROUP_PRICE)) }}
+              {{ (attendee.amount_extra_unpaid + (attendee.badges|int * c.GROUP_PRICE))|format_currency }}
             {% else %}
-              ${{ '%0.2f' % attendee.total_cost }}
+              {{ attendee.total_cost|format_currency }}
             {% endif %}
           </td>
           <td>
@@ -150,7 +150,7 @@
               {% endfor %}
             </ul>
           </td>
-          <td>${{ '%0.2f' % group.default_cost }}</td>
+          <td>{{ group.default_cost|format_currency }}</td>
           <td>
             <a href="form?edit_id={{ group.id }}">Edit</a> /
             <a href="delete?id={{ group.id }}">Delete</a>
@@ -163,7 +163,7 @@
         <tr>
           <th></th>
           <th style="text-align:right;"><i>Total:</i></th>
-          <th><b>${{ '%0.2f' % charge.dollar_amount }}</b></th>
+          <th><b>{{ charge.dollar_amount|format_currency }}</b></th>
           <th></th>
         </tr>
       </tfoot>

--- a/uber/templates/preregistration/paid_preregistrations.html
+++ b/uber/templates/preregistration/paid_preregistrations.html
@@ -17,7 +17,7 @@
         {% if total_cost|int > 0 %}
             <p>
                 Your credit card was successfully charged for
-                <strong>${{ '%0.2f' % total_cost|float }}</strong>, and you will receive a confirmation
+                <strong>{{ total_cost|format_currency }}</strong>, and you will receive a confirmation
                 email sent to you shortly. If you paid for other registrations, those
                 attendees will get their own confirmation email.
             </p>

--- a/uber/templates/preregistration/repurchase.html
+++ b/uber/templates/preregistration/repurchase.html
@@ -10,7 +10,7 @@
 
     <p>
     According to our records, your badge has been refunded. You may repurchase your badge at the current price of
-    ${{ c.BADGE_PRICE }} for an Attendee badge. We will pre-fill your details into the pre-registration form.
+    {{ c.BADGE_PRICE|format_currency }} for an Attendee badge. We will pre-fill your details into the pre-registration form.
     </p>
 
     <form method="post" action="repurchase" class="form-horizontal">

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -54,10 +54,10 @@ $().ready(function() {
 <div class="panel panel-body"><h3>Add Payment or Refund</h3>
 <p>Use the Stripe Payment History table at the bottom of this page to associate a payment or refund with a Stripe transaction. Please <b>only</b> add payments if the attendee has paid.</p>
 {% if model.purchased_items %}<p>This attendee has purchased the following:
-<br/> {% for name, val in model.purchased_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
+<br/> {% for name, val in model.purchased_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: {{ val|format_currency }}<br/>{% endfor %}
 </p>{% endif %}
 {% if model.refunded_items %}<p>We have marked the following items as refunded:
-<br/> {% for name, val in model.refunded_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}
+<br/> {% for name, val in model.refunded_items.items() %}{{ name[:-5]|replace('_', ' ')|title }}: {{ val|format_currency }}<br/>{% endfor %}
 </p>{% endif %}
 <form class="form" method="post" action="add_receipt_item" id="add_receipt_item" role="form">
 <input type="hidden" name="id" value="{{ model.id }}" />
@@ -132,9 +132,9 @@ $().ready(function() {
         <td>{{ item.when|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
         <td>{{ item.who }}</td>
         <td>{{ item.desc }}{% if item.fk_id %}({{ item.model }}){% endif %}</td>
-        <td>${{ '%0.2f' % (item.amount / 100) }} {{ item.type_label }}</td>
-        <td>{{ 'N/A' if item.cost_snapshot == {} }}{% for name, val in item.cost_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}<br/>{% endfor %}</td>
-        <td>{{ 'N/A' if item.refund_snapshot == {} }}{% for name, val in item.refund_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: ${{ val }}{% endfor %}</td>
+        <td>{{ (item.amount / 100)|format_currency }} {{ item.type_label }}</td>
+        <td>{{ 'N/A' if item.cost_snapshot == {} }}{% for name, val in item.cost_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: {{ val|format_currency }}<br/>{% endfor %}</td>
+        <td>{{ 'N/A' if item.refund_snapshot == {} }}{% for name, val in item.refund_snapshot.items() %}{{ name[:-5]|replace('_', ' ')|title }}: {{ val|format_currency }}{% endfor %}</td>
         <td>{{ item.txn_type_label }}</td>
         <td>
           <form class="form-inline" method="post" action="remove_receipt_item" role="form">
@@ -166,7 +166,7 @@ $().ready(function() {
     {{ name[:-5]|replace('_', ' ')|title }}
   </td>
   <td>
-    ${{ val }}
+    {{ val|format_currency }}
   </td>
   <td>
   <form class="form-inline" method="post" action="add_refund_item" role="form">
@@ -187,7 +187,7 @@ $().ready(function() {
     {{ name[:-5]|replace('_', ' ')|title }}
   </td>
   <td>
-    ${{ val }}
+    {{ val|format_currency }}
   </td>
   <td>
   <form class="form-inline" method="post" action="remove_refund_item" role="form">
@@ -220,8 +220,8 @@ $().ready(function() {
   {% for log in model.stripe_txn_share_logs %}
       <tr>
       <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.stripe_id }}</td>
-      <td valign="top" style="white-space:nowrap">${{ '%0.2f' % (log.share / 100) }}
-      <td valign="top" style="white-space:nowrap">${{ '%0.2f' % (log.stripe_transaction.amount / 100) }} {{ log.stripe_transaction.type_label }}</td>
+      <td valign="top" style="white-space:nowrap">{{ (log.share / 100)|format_currency }}
+      <td valign="top" style="white-space:nowrap">{{ (log.stripe_transaction.amount / 100)|format_currency }} {{ log.stripe_transaction.type_label }}</td>
       <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.when|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
       <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.who }}</td>
       <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.desc }}</td>

--- a/uber/templates/reg_reports/self_service_refunds.html
+++ b/uber/templates/reg_reports/self_service_refunds.html
@@ -34,7 +34,7 @@
         <td>
           {{ refund.created.when|datetime_local }}
         </td>
-        <td>{{ "${:,.2f}".format(refund.amount/100) }}</td>
+        <td>{{ (refund.amount / 100)|format_currency }}</td>
         <td>
           {{ refund.who }}
         </td>

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -5,7 +5,7 @@
   <div class="modal-body">
 {% if attendee.amount_unpaid %}
 <div class="center text-center check-in">
-<h4>{{ attendee.full_name }} currently owes <strong>${{ '%0.2f' % attendee.amount_unpaid  }}</strong>.</h4>
+<h4>{{ attendee.full_name }} currently owes <strong>{{ attendee.amount_unpaid|format_currency }}</strong>.</h4>
 <form method="post" action="mark_as_paid">
 {{ csrf_token() }}
 <input type="hidden" name="id" value="{{ attendee.id }}" />

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -126,7 +126,7 @@
 </div>
 {% if c.AT_THE_CON and attendee.amount_unpaid %}
 <div class="alert alert-warning center" role="alert" id="payment-warning">
-<h4>{{ attendee.full_name }} currently owes <strong>${{ '%0.2f' % attendee.amount_unpaid }}</strong>.</h4>
+<h4>{{ attendee.full_name }} currently owes <strong>{{ attendee.amount_unpaid|format_currency }}</strong>.</h4>
 {% if Charge %}
 {{ stripe_form('manual_reg_charge', attendee) }}
 {% else %}

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -196,7 +196,7 @@
                         <td>Can't checkin ({{ attendee.is_not_ready_to_checkin }})</td>
                     {% else %}
                       {% if not reg_station and attendee.amount_unpaid %}
-                        <td>Can't checkin (Attendee owes ${{ '%0.2f' % attendee.amount_unpaid }})</td>
+                        <td>Can't checkin (Attendee owes {{ attendee.amount_unpaid|format_currency }})</td>
                       {% else %}
                         <td id="cin_{{ attendee.id }}">
                             <button class="attendee-checkin btn-sm btn-success" data-attendee-id="{{ attendee.id }}" onClick="loadCheckInModal('{{ attendee.id }}')">Check In</button>

--- a/uber/templates/registration/new_base.html
+++ b/uber/templates/registration/new_base.html
@@ -260,7 +260,7 @@
                 {{ attendee.age_group_conf.desc }}
             {% endif %}
         </td>
-        <td>{% if attendee.paid != c.PAID_BY_GROUP %}${{ '%0.2f' % attendee.total_cost }}{% endif %}</td>
+        <td>{% if attendee.paid != c.PAID_BY_GROUP %}{{ attendee.total_cost|format_currency }}{% endif %}</td>
         <td>
             {% if attendee.paid == c.HAS_PAID %}
                 paid

--- a/uber/templates/registration/promo_code_group_form.html
+++ b/uber/templates/registration/promo_code_group_form.html
@@ -102,7 +102,7 @@
             {{ code.used_by[0]|form_link if code.used_by else 'N/A' }}
           </td>
           <td>{{ code.created.when|datetime_local }}</td>
-          <td>${{ '%0.2f' % code.cost }}</td>
+          <td>{{ code.cost|format_currency }}</td>
         </tr>
       {% endfor -%}
       </tbody>

--- a/uber/templates/registration/reg_take_report.html
+++ b/uber/templates/registration/reg_take_report.html
@@ -41,9 +41,9 @@
         &nbsp; / &nbsp;
         Total Fees Taken: {{ sales|length }}
         &nbsp; / &nbsp;
-        Total Cash: ${{ '%0.2f' % total_cash }}
+        Total Cash: {{ total_cash|format_currency }}
         &nbsp; / &nbsp;
-        Total Credit: ${{ '%0.2f' % total_credit }}
+        Total Credit: {{ total_credit|format_currency }}
     </div>
     <table class="list">
     <tr class="header">
@@ -58,7 +58,7 @@
             <td>{{ sale.what }}</td>
             <td><a href="./form?id={{ sale.attendee_id }}">{{ sale.attendee.full_name }}</a></td>
             <td>{{ sale.payment_method_label }}</td>
-            <td>${{ '%0.2f' % sale.cash }}</td>
+            <td>{{ sale.cash|format_currency }}</td>
             <td>{{ sale.when }}</td>
         </tr>
     {% endfor %}
@@ -77,7 +77,7 @@
             <td><a href="#attendee_form?id={{ attendee.id }}">{{ attendee.full_name }}</a></td>
             <td>{{ attendee.badge }}</td>
             <td>{{ attendee.payment_method_label }}</td>
-            <td>${{ '%0.2f' % (attendee.amount_paid / 100) }}</td>
+            <td>{{ (attendee.amount_paid / 100)|format_currency }}</td>
             <td>{{ attendee.registered }}</td>
         </tr>
     {% endfor %}

--- a/uber/templates/static_views/prereg_closed.html
+++ b/uber/templates/static_views/prereg_closed.html
@@ -2,7 +2,7 @@
     <h2 style='color:red'>{{ c.EVENT_NAME_AND_YEAR }} pre-registration has closed.</h2>
     We'll see everyone {{ c.EVENT_MONTH }} {{ c.EVENT_START_DAY }} - {{ c.EVENT_END_DAY }}.<br/>
     <br/>
-    Full weekend passes will be available at the door for ${{ c.BADGE_PRICE }}. Single days passes will be available for {{ single_day_prices() }}. We do not anticipate selling out, so you should have no problem purchasing a pass at-event.<br/>
+    Full weekend passes will be available at the door for {{ c.BADGE_PRICE|format_currency }}. Single days passes will be available for {{ single_day_prices() }}. We do not anticipate selling out, so you should have no problem purchasing a pass at-event.<br/>
     <br/>
     Please <a href="{{ c.CONTACT_URL }}">contact us</a> if you have any questions.<br/>
 </body></html>

--- a/uber/templates/statistics/affiliates.html
+++ b/uber/templates/statistics/affiliates.html
@@ -24,12 +24,12 @@
 {% for affiliate, totals in counts %}
     <tr>
         <td><b>{{ affiliate }}</b></td>
-        <td><nobr><b>${{ '%0.2f' % totals.total }}</b></nobr></td>
+        <td><nobr><b>{{ totals.total|format_currency }}</b></nobr></td>
         <td><nobr><b>{{ totals.tally }} attendee{{ totals.tally|pluralize }}</b></nobr></td>
         <td>
             <ul>
             {% for amount, count in totals.sorted %}
-                <li>{{ count }} attendee{{ count|pluralize }} gave ${{ '%0.2f' % amount }}</li>
+                <li>{{ count }} attendee{{ count|pluralize }} gave {{ amount|format_currency }}</li>
             {% endfor %}
             </ul>
         </td>

--- a/uber/templates/statistics/index.html
+++ b/uber/templates/statistics/index.html
@@ -14,7 +14,7 @@
 {% endif %}
 <b>Number of remaining badges for sale (before event is sold out):</b> {{ c.REMAINING_BADGES }} <br/>
 {% for amount, count in counts.donation_tiers.items() %}
-  <b>Number of attendees who've donated at the ${{ '%0.2f' % amount }} level:</b> {{ count }} <br>
+  <b>Number of attendees who've donated at the {{ amount|format_currency }} level:</b> {{ count }} <br>
 {% endfor %}
 
 <h4>Badge Types</h4>


### PR DESCRIPTION
Adds a custom filter for formatting currency in templates and applies it, allowing us to avoid display errors like "$10.0"

I separated this out from https://github.com/MidwestFurryFandom/rams/pull/382 so this can be reviewed separately without ~70 template changes cluttering up the other PR.