### PR TITLE
Fix logged-in accounts

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -665,8 +665,16 @@ class Session(SessionManager):
             if c.ATTENDEE_ACCOUNTS_ENABLED and getattr(cherrypy, 'session', {}).get('attendee_account_id'):
                 return self.attendee_account(cherrypy.session.get('attendee_account_id'))
         
-        def one_badge_attendee_account(self):
-            account = self.current_attendee_account()
+        def one_badge_attendee_account(self, attendee):
+            logged_in_account = self.current_attendee_account()
+            attendee_accounts = attendee.managers
+            if logged_in_account in attendee_accounts:
+                account = logged_in_account
+            elif len(attendee.managers) == 1:
+                account = attendee.managers[0]
+            else:
+                return
+
             if account and account.has_only_one_badge:
                 return account
 

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -93,7 +93,7 @@ class Root:
         return {
             'message': message,
             'app': app,
-            'show_account': session.one_badge_attendee_account(),
+            'account': session.one_badge_attendee_account(app.attendee),
             'return_to': 'edit?id={}'.format(app.id),
         }
 

--- a/uber/site_sections/marketplace.py
+++ b/uber/site_sections/marketplace.py
@@ -91,7 +91,7 @@ class Root:
         return {
             'message': message,
             'app': app,
-            'show_account': session.one_badge_attendee_account(),
+            'account': session.one_badge_attendee_account(app.attendee),
             'return_to': 'edit?id={}'.format(app.id),
         }
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -701,6 +701,7 @@ class Root:
             raise HTTPRedirect('group_members?id={}&message={}', group.id, message)
         return {
             'group':   group,
+            'account': session.one_badge_attendee_account(group.leader),
             'upgraded_badges': len([a for a in group.attendees if a.badge_type in c.BADGE_TYPE_PRICES]),
             'message': message
         }
@@ -1117,7 +1118,7 @@ class Root:
             'undoing_extra': undoing_extra,
             'return_to':     return_to,
             'attendee':      attendee,
-            'show_account':  session.one_badge_attendee_account(),
+            'account':       session.one_badge_attendee_account(attendee),
             'message':       message,
             'affiliates':    session.affiliates(),
             'attractions':   session.query(Attraction).filter_by(is_public=True).all(),

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -4,6 +4,7 @@ from uber.models.attendee import AttendeeAccount
 import cherrypy
 from pockets import groupify, listify
 from sqlalchemy import and_, or_, func
+from sqlalchemy.orm import joinedload, raiseload
 from sqlalchemy.orm.exc import NoResultFound
 
 from uber.config import c, _config
@@ -91,7 +92,7 @@ class Root:
     def attendee_accounts(self, session, message=''):
         return {
             'message': message,
-            'accounts': session.query(AttendeeAccount).all(),
+            'accounts': session.query(AttendeeAccount).options(joinedload(AttendeeAccount.attendees), raiseload('*')).all(),
         }
 
     def delete_attendee_account(self, session, id, message='', **params):

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -5,7 +5,7 @@
 <script type="text/javascript">{% include "region_opts.html" %}</script>
 <div class="masthead"></div>
 {% set attendee = app.attendee %}
-{% if show_account %}
+{% if account %}
   {% include 'preregistration/update_account.html' %}
 {% endif %}
 <div class="panel panel-default">

--- a/uber/templates/confirm_tabs.html
+++ b/uber/templates/confirm_tabs.html
@@ -25,6 +25,13 @@
 </style>
 
 <ul class="nav nav-tabs" role="tablist">
+  {% if attendee.is_group_leader %}
+  <li role="presentation"{% if 'group_members' in c.PAGE_PATH %} class="active"{% endif %}>
+    <a href="../preregistration/group_members?id={{ attendee.group.id }}">
+      <span class="glyphicon glyphicon-briefcase"></span> {% if attendee.group.is_dealer %}Dealer Application{% else %}Manage {{ attendee.group.name }}{% endif %}
+    </a>
+  </li>
+  {% endif %}
   <li role="presentation"{% if 'confirm' in c.PAGE_PATH %} class="active"{% endif %}>
     <a href="../preregistration/confirm?id={{ attendee.id }}">
       <span class="glyphicon glyphicon-user"></span> {{ attendee.full_name }}'s Info

--- a/uber/templates/marketplace/edit.html
+++ b/uber/templates/marketplace/edit.html
@@ -4,7 +4,7 @@
 {% set payment_includes_badge = app.attendee.badge_cost and app.attendee.amount_unpaid > app.total_cost %}
 <div class="masthead"></div>
 {% set attendee = app.attendee %}
-{% if show_account %}
+{% if account %}
   {% include 'preregistration/update_account.html' %}
 {% endif %}
 <div class="panel panel-default">

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -5,9 +5,6 @@
 {% block title %}Confirm Your Details{% endblock %}
 {% block backlink %}
 {{ super() }}
-    {% if c.HAS_REGISTRATION_ACCESS %}
-        <a class="pull-right" style="padding-right:5px;" href="../registration/form?id={{ attendee.id }}">Return to Attendee Admin Form</a>
-    {% endif %}
 {% endblock %}
 {% block content %}
 
@@ -29,7 +26,7 @@
 </script>
 
 {% include 'prereg_masthead.html' %}
-{% if show_account %}
+{% if account %}
   {% include 'preregistration/update_account.html' %}
 {% endif %}
 <div class="panel panel-default">
@@ -37,7 +34,7 @@
     Registration Information
   </div>
   <div class="panel-body">
-    {% if (c.ATTRACTIONS_ENABLED and attractions) or attendee.promo_code_groups or attendee.art_show_applications or attendee.marketplace_applications %}
+    {% if (c.ATTRACTIONS_ENABLED and attractions) or attendee.promo_code_groups or attendee.art_show_applications or attendee.marketplace_applications or attendee.is_group_leader %}
       {% include 'confirm_tabs.html' with context %}
     {% endif %}
     {% block panel_top %}{% endblock %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -2,12 +2,6 @@
 {% set page_ro = True if group.status in [c.APPROVED, c.CANCELLED, c.DECLINED] else False %}
 {% import "fields/group.html" as group_fields with context %}
 {% block title %}Group Members{% endblock %}
-{% block backlink %}
-{{ super() }}
-    {% if c.HAS_GROUP_ADMIN_ACCESS %}
-        <a href="../group_admin/form?id={{ group.id }}" style="float:right">Return to Group Admin Form</a>
-    {% endif %}
-{% endblock %}
 {% block content %}
 <script type="text/javascript">
     $().ready(function() {
@@ -60,8 +54,15 @@
 </script>
 
 {% include 'prereg_masthead.html' %}
+{% if account %}
+  {% include 'preregistration/update_account.html' %}
+{% endif %}
 <div class="panel panel-default">
   <div class="panel-body">
+    {% if group.leader %}
+    {% set attendee = group.leader %}
+    {% include 'confirm_tabs.html' with context %}
+    {% endif %}
     {% if group.is_dealer %}
       {{ group_fields.status }}
       <h2>"{{ group.name }}" Information</h2>

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -1,12 +1,6 @@
 {% extends "preregistration/preregbase.html" %}
 {% block title %}Group Members{% endblock %}
 {% set attendee = group.buyer %}
-{% block backlink %}
-  {{ super() }}
-  {% if c.HAS_REGISTRATION_ACCESS %}
-    <a href="../registration/form?id={{ attendee.id }}" style="float:right">Return to Attendee Admin Form</a>
-  {% endif %}
-{% endblock %}
 {% block content %}
   <script type="text/javascript">
       toggleEmailForm = function(code) {

--- a/uber/templates/preregistration/homepage.html
+++ b/uber/templates/preregistration/homepage.html
@@ -1,11 +1,5 @@
 {% extends "preregistration/preregbase.html" %}
 {% block title %}Manage Your Registrations{% endblock %}
-{% block backlink %}
-    {{ super() }}
-    {% if c.HAS_REGISTRATION_ACCESS and false %}
-        <a href="../registration/form?id={{ attendee.id }}" style="float:right">Return to Attendee Admin Form</a>
-    {% endif %}
-{% endblock %}
 {% block content %}
 {% include 'prereg_masthead.html' %}
 {% include 'preregistration/update_account.html' %}

--- a/uber/templates/preregistration/preregbase.html
+++ b/uber/templates/preregistration/preregbase.html
@@ -3,9 +3,16 @@
     {{ super() }}
 {% endblock head_javascript %}
 {% block backlink %}
-{% if c.ATTENDEE_ACCOUNTS_ENABLED %}
+{% if c.ATTENDEE_ACCOUNTS_ENABLED or c.HAS_REGISTRATION_ACCESS or c.HAS_GROUP_ADMIN_ACCESS %}
 <div class="pull-right" style="padding-top:5px;">
-    {% if not show_account and c.PAGE_PATH != '/preregistration/homepage' %}<a class="btn btn-info" href="../preregistration/homepage">Homepage</a>{% endif %}
+    {% if c.HAS_REGISTRATION_ACCESS and attendee %}
+    <a class="btn btn-default" href="../registration/form?id={{ attendee.id }}">Admin Form</a>
+    {% elif c.HAS_GROUP_ADMIN_ACCESS and group %}
+    <a class="btn btn-default" href="../group_admin/form?id={{ group.id }}">Admin Form</a>
+    {% endif %}
+    {% if not account and c.PAGE_PATH != '/preregistration/homepage' %}
+    <a class="btn btn-info" href="../preregistration/homepage">Homepage</a>
+    {% endif %}
     <a class="btn btn-danger" href="../preregistration/logout">Logout</a>
 </div>
 {% endif %}

--- a/uber/templates/preregistration/update_account.html
+++ b/uber/templates/preregistration/update_account.html
@@ -43,14 +43,14 @@
     <div class="panel-footer">
         <div class="btn-group">
             <a href="../preregistration/form" class="btn btn-primary" target="_blank">Add Registration(s)</a>
-            {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.DEALER_REG_OPEN %}
+            {% if c.DEALER_REG_START and c.DEALER_REG_PUBLIC and c.DEALER_REG_OPEN and (not group or not group.is_dealer) and (not attendee or not attendee.is_dealer) %}
             <a href="../preregistration/dealer_registration" class="btn btn-success" target="_blank">Apply as Dealer</a>
             {% endif %}
             {% if attendee %}
-                {% if c.ART_SHOW_OPEN %}
+                {% if c.ART_SHOW_OPEN and not attendee.art_show_applications %}
                 <a href="../art_show_applications/index?attendee_id={{ attendee.id }}" class="btn btn-info" target="_blank">Apply for Art Show</a>
                 {% endif %}
-                {% if c.AFTER_MARKETPLACE_REG_START and c.BEFORE_MARKETPLACE_DEADLINE %}
+                {% if c.AFTER_MARKETPLACE_REG_START and c.BEFORE_MARKETPLACE_DEADLINE and not attendee.marketplace_applications %}
                 <a href="../marketplace/index?attendee_id={{ attendee.id }}" class="btn btn-default" target="_blank">Apply for Marketplace</a>
                 {% endif %}
             {% endif %}


### PR DESCRIPTION
There were a few regressions introduced recently around logged-in accounts. This fixes that, plus it fixes a minor bug with admins viewing attendee pages and (hopefully) makes the attendee accounts admin page efficient enough to use.

Fixes https://github.com/MidwestFurryFandom/rams/issues/402. Fixes https://github.com/MidwestFurryFandom/rams/issues/403.