### PR TITLE
Send dealer paid email via payment webhook

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -798,16 +798,6 @@ class Root:
 
             session.merge(group)
             session.commit()
-            if group.is_dealer:
-                try:
-                    send_email.delay(
-                        c.MARKETPLACE_EMAIL,
-                        c.MARKETPLACE_EMAIL,
-                        '{} Payment Completed'.format(c.DEALER_TERM.title()),
-                        render('emails/dealers/payment_notification.txt', {'group': group}, encoding=None),
-                        model=group.to_dict('id'))
-                except Exception:
-                    log.error('unable to send {} payment confirmation email'.format(c.DEALER_TERM), exc_info=True)
                     
             return {'stripe_intent': stripe_intent,
                     'success_url': 'group_members?id={}&message={}'.format(group.id, 'Your payment has been accepted')}
@@ -883,13 +873,6 @@ class Root:
             )
             session.merge(group)
             session.commit()
-            if group.is_dealer:
-                send_email.delay(
-                    c.MARKETPLACE_EMAIL,
-                    c.MARKETPLACE_EMAIL,
-                    '{} Paid for Extra Members'.format(c.DEALER_TERM.title()),
-                    render('emails/dealers/payment_notification.txt', {'group': group}, encoding=None),
-                    model=group.to_dict('id'))
             
             return {'stripe_intent': stripe_intent,
                     'success_url': 'group_members?id={}&message={}'.format(

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1144,8 +1144,12 @@ class Charge:
 
     @staticmethod
     def mark_paid_from_stripe_id(stripe_id):
+        from uber.tasks.email import send_email
+        from uber.decorators import render
+        
         with uber.models.Session() as session:
             matching_stripe_txns = session.query(uber.models.StripeTransaction).filter_by(stripe_id=stripe_id)
+            dealers_paid = []
 
             for txn in matching_stripe_txns:
                 txn.type = c.PAYMENT
@@ -1160,6 +1164,8 @@ class Charge:
                     if not group.amount_pending:
                         group.paid = c.HAS_PAID
                         session.add(group)
+                        if group.is_dealer:
+                            dealers_paid.append(group)
 
                 for attendee_log in txn.attendees:
                     attendee = attendee_log.attendee
@@ -1170,4 +1176,16 @@ class Charge:
                         session.add(attendee)
 
             session.commit()
+
+            for group in dealers_paid:
+                try:
+                    send_email.delay(
+                        c.MARKETPLACE_EMAIL,
+                        c.MARKETPLACE_EMAIL,
+                        '{} Payment Completed'.format(c.DEALER_TERM.title()),
+                        render('emails/dealers/payment_notification.txt', {'group': group}, encoding=None),
+                        model=group.to_dict('id'))
+                except Exception:
+                    log.error('unable to send {} payment confirmation email'.format(c.DEALER_TERM), exc_info=True)
+
             return matching_stripe_txns


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/430. If we send the email during the payment page handler, the email gets sent before the webhook has a chance to actually mark the dealer as paid. Now we'll only send it when the dealer is counted as paid.