### PR TITLE
Fix num_event_shirts_label 500 error

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -350,6 +350,9 @@ class MagModel:
             log.debug('{} is not an int. Did we forget to migrate data for {} during a DB migration?', val, name)
             return ''
 
+        if val == -1:
+            return "Unknown"
+
         label = self.get_field(name).type.choices.get(val)
         if not label:
             log.debug('{} does not have a label for {}, check your enum generating code', name, val)


### PR DESCRIPTION
We set num_event_shirts to default to -1, which is supposed to represent an unselected choice, but that was causing an error when trying to access its label. We now special-case -1  -- which would only be set explicitly in code for Choice columns -- to return a default "Unknown" label.