### PR TITLE
Fix typo in art show print template variable

### DIFF
--- a/uber/templates/art_show_common/print_macros.html
+++ b/uber/templates/art_show_common/print_macros.html
@@ -107,7 +107,7 @@
     <td><strong>Commission</strong></td><td>{{ (app.commission / 100)|format_currency }}</td>
   </tr>
   <tr><td><strong>Name on Check</strong></td><td>{{ app.check_payable or app.attendee.legal_first_name ~ " " ~ app.attendee.legal_last_name }}</td></tr>
-  <tr><td><strong>Check Total</strong></td><td>{{ (app.check_total / 100|format_currency) }}</td></tr>
+  <tr><td><strong>Check Total</strong></td><td>{{ (app.check_total / 100)|format_currency }}</td></tr>
 </table>
 <div class="form-group">
   <label class="col-sm-3 control-label optional-field">Artist Signature</label>


### PR DESCRIPTION
Fixes a bug received via email -- a typo on this line causes the print function to fail because it can't parse the template.