### PR TITLE
Fix high-priority Art Show errors

### DIFF
--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -87,7 +87,7 @@ class ArtShowApplication(MagModel):
 
             if not code_candidate:
                 # We're out of manual alternatives, time for a random code
-                code_candidates = ''.join([random.choice(string.ascii_uppercase) for _ in range(100)])
+                code_candidates = ''.join([random.choices(string.ascii_uppercase, 3) for _ in range(100)])
                 for code_candidate in code_candidates:
                     if code_candidate not in old_codes:
                         break

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -67,7 +67,7 @@ class Root:
     def edit(self, session, message='', **params):
         app = session.art_show_application(params, restricted=True,
                                            ignore_csrf=True)
-        return_to = params.get('return_to', '/art_show_applications/edit?id={}'.format(app.id))
+        return_to = params.get('return_to', '/art_show_applications/edit')
         if not params.get('id'):
             message = 'Invalid art show application ID. ' \
                       'Please try going back in your browser.'

--- a/uber/templates/preregistration/confirm.html
+++ b/uber/templates/preregistration/confirm.html
@@ -39,6 +39,10 @@
     {% endif %}
     {% block panel_top %}{% endblock %}
 
+    {% if c.ART_SHOW_ENABLED and not attendee.is_new %}
+      {% include 'art_show_common/art_show_agent.html' %}
+    {% endif %}
+
     <form method="post" action="confirm" class="form-horizontal">
       {{ csrf_token() }}
       <input type="hidden" name="id" value="{{ attendee.id }}" />


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/450. Fixes https://github.com/MidwestFurryFandom/rams/issues/463. Also fixes a previously undiscovered bug that redirected artists to a 404 error after saving their application.