### PR TITLE
Fix attendee creation via modal

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -481,25 +481,23 @@
 
 {% set name %}
 {% set read_only = name_ro or (page_ro and not (limited_write or contact_write)) %}
-{% if not admin_area %}
-  <script type="text/javascript">
-      var sameLegalNameChecked = function () {
-          if ($("#same_legal_name").prop('checked')) {
-              $.field('legal_name').prop('readonly', true).val('').prop('required', false).valid();
-              $("label[for='legal_name']").addClass('optional-field');
-          } else if ($("#same_legal_name").length) {
-              $.field('legal_name').prop('readonly', false).prop('required', true);
-              $("label[for='legal_name']").removeClass('optional-field');
-          }
-      };
-      $(window).on("runJavaScript", function () {
-          if ($('#same_legal_name').length) {
-              sameLegalNameChecked();
-              $('#same_legal_name').change(sameLegalNameChecked);
-          }
-      })
-  </script>
-{% endif %}
+<script type="text/javascript">
+    var sameLegalNameChecked = function () {
+        if ($("#same_legal_name").prop('checked')) {
+            $.field('legal_name').prop('readonly', true).val('').prop('required', false).valid();
+            $("label[for='legal_name']").addClass('optional-field');
+        } else if ($("#same_legal_name").length) {
+            $.field('legal_name').prop('readonly', false).prop('required', true);
+            $("label[for='legal_name']").removeClass('optional-field');
+        }
+    };
+    $(window).on("runJavaScript", function () {
+        if ($('#same_legal_name').length) {
+            sameLegalNameChecked();
+            $('#same_legal_name').change(sameLegalNameChecked);
+        }
+    })
+</script>
 <div class="form-group">
   <label for="first_name" class="col-sm-3 control-label">Name</label>
   {% call macros.read_only_if(read_only, attendee.masked_name if limited_read else attendee.full_name) %}
@@ -516,12 +514,12 @@
   {% endcall %}
 </div>
 
-{% if not admin_area and not read_only %}
+{% if not read_only %}
   <div class="form-group">
     <div class="col-sm-9 col-sm-offset-3">
       <label for="same_legal_name" class="checkbox-label">
         <input type="checkbox" name="same_legal_name" id="same_legal_name" value="1" {% if attendee.first_name != '' and attendee.legal_name == '' %}checked="checked"{% endif %} />
-        The above name is exactly what appears on my Legal Photo ID
+        The above name is exactly what appears on {{ "my" if not admin_area else "their" }} Legal Photo ID
       </label>
     </div>
   </div>
@@ -1837,10 +1835,9 @@ $(window).on("runJavaScript", function(){
 {% endset %}
 
 
-{% set reprint_fee %}
+{% set print_badge %}
 {% if c.BADGE_REPRINT_FEE %}
-{# This field currently breaks the page flow and should be replaced with an AJAX call. #}
-<div class="form-group">
+<div class="form-group" id="reprint_fee">
   <label class="col-sm-3 control-label">Reprint Badge</label>
   <div class="col-sm-6">
       <form role="form" method="post" action="../badge_printing/reprint_fee">
@@ -1852,6 +1849,10 @@ $(window).on("runJavaScript", function(){
       </form>
   </div>
 </div>
+
+<script type="text/javascript">
+  $('#reprint_fee').insertAfter($.field('badge_status').parents('.form-group'));
+</script>
 {% endif %}
 {% endset %}
 {% endif %}

--- a/uber/templates/registration/attendee_data.html
+++ b/uber/templates/registration/attendee_data.html
@@ -82,6 +82,7 @@ if($.field('return_to')) {
     {{ attendee_fields.badge_type }}
     {{ attendee_fields.ribbons }}
     {{ attendee_fields.name }}
+    {{ attendee_fields.age }}
     {{ attendee_fields.email }}
     {{ attendee_fields.paid }}
     {{ attendee_fields.admin_notes }}
@@ -93,7 +94,6 @@ if($.field('return_to')) {
     {{ attendee_fields.is_placeholder }}
     {{ attendee_fields.badge_status }}
     {{ attendee_fields.print_pending }}
-    {{ attendee_fields.reprint_fee }}
     {% if c.HAS_ACCOUNTS_ACCESS %}
       {{ attendee_fields.admin_access }}
     {% endif %}
@@ -118,6 +118,9 @@ if($.field('return_to')) {
     {{ attendee_fields.admin_notes }}
   {% endif %}
 </form>
+{% if not attendee.is_new %}
+{{ attendee_fields.print_badge }}
+{% endif %}
 <div class="modal-footer">
   <div class="form-group">
   {% if not attendee.is_new %}

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -31,7 +31,6 @@
 {{ attendee_fields.is_placeholder }}
 {{ attendee_fields.badge_status }}
 {{ attendee_fields.print_pending }}
-{{ attendee_fields.reprint_fee }}
 {% if c.HAS_ACCOUNTS_ACCESS %}
   {{ attendee_fields.admin_access }}
 {% endif %}
@@ -98,6 +97,8 @@
 
 </form>
 
+{{ attendee_fields.print_badge }}
+
 {% if not attendee.is_new %}
     <div style="margin-left:25%">
         <form method="post" id="delete_attendee" action="delete" onSubmit="return confirm('{% if attendee.group and attendee.is_unassigned %}Are you sure you want to delete this unassigned badge?{% elif attendee.group %}Are you sure you want to unassign this badge?{% else %}Are you sure you want to delete this attendee?{% endif %}');">
@@ -124,7 +125,7 @@
 {% endif %}
 </div>
 </div>
-{% if c.AT_THE_CON and attendee.amount_unpaid %}
+{% if c.AT_THE_CON and attendee.amount_unpaid and not attendee.is_new %}
 <div class="alert alert-warning center" role="alert" id="payment-warning">
 <h4>{{ attendee.full_name }} currently owes <strong>{{ attendee.amount_unpaid|format_currency }}</strong>.</h4>
 {% if Charge %}


### PR DESCRIPTION
You could only create placeholder attendees via the modal because the DOB field wasn't being included. This fixes that. Also cleans up the reprint_fee field a bit so it's properly integrated, adds the 'legal name' checkbox for admins to reduce confusion, and removes the at-con payment warning if you're creating a new attendee.