### PR TITLE
Merge art show incomplete_reason to main plugin

### DIFF
--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -126,6 +126,8 @@ class ArtShowApplication(MagModel):
         if self.delivery_method == c.BY_MAIL \
                 and not self.address1:
             return "Mailing address required"
+        if not self.attendee:
+            return "No attendee assigned to application"
         if self.attendee.placeholder and self.attendee.badge_status != c.NOT_ATTENDING:
             return "Missing registration info"
 


### PR DESCRIPTION
We were redefining the incomplete_reason inside mff-rams-plugin, but there's no longer a reason for the main and mff plugin to treat art show apps differently, so this merges them to make code maintenance easier.