### PR TITLE
Improve toastr error messages

### DIFF
--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -228,12 +228,21 @@
                 hideMethod: "fadeOut",
                 onShown: function() {
                   replaceQueryParamInUrl('message');
+                  replaceQueryParamInUrl('error_message');
                 }
             };
-            var message = '{{ message }}';
-            var error_message = '{{ error_message }}';
+            var message = '{{ message|safe }}';
+            var error_message = '{{ error_message|safe }}';
             if (error_message.length) {
-                toastr.error(error_message);
+                if (error_message.startsWith("ERROR: ")) {
+                    toastr.error(error_message.substr(7));
+                } else {
+                    toastr.error(error_message);
+                }
+            } else if (message.length && message.startsWith("ERROR: ")) {
+                toastr.error(message.substr(7));
+            } else if (message.length && message.startsWith("SUCCESS: ")) {
+                toastr.success(message.substr(9));
             } else if (message.length) {
                 toastr.info(message);
             }

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -451,9 +451,10 @@ def check(model, *, prereg=False):
     Returns:
         str: None for success, or a failure message if validation fails.
     """
+    errors = []
     for field, name in model.required:
         if not str(getattr(model, field)).strip():
-            return name + ' is a required field'
+            errors.append(name + ' is a required field')
 
     validations = [uber.model_checks.validation.validations]
     prereg_validations = [uber.model_checks.prereg_validation.validations] if prereg else []
@@ -461,7 +462,8 @@ def check(model, *, prereg=False):
         for validator in v[model.__class__.__name__].values():
             message = validator(model)
             if message:
-                return message
+                errors.append(message)
+    return "ERROR: " + "<br>".join(errors) if errors else None
 
 
 def check_all(models, *, prereg=False):


### PR DESCRIPTION
While working on the badge printing I figured out how to make multiple errors properly appear in toastr message pop-ups. This doesn't fix every case, but now the check() function will return more than one error at a time, greatly improving UX when filling out forms.

![image](https://user-images.githubusercontent.com/7198215/140552444-13c81600-90eb-4934-a0cb-68d43f7de8f9.png)