### PR TITLE
Add PrintJob table and API

### DIFF
--- a/alembic/versions/40ec91ad7a74_add_print_queue_table.py
+++ b/alembic/versions/40ec91ad7a74_add_print_queue_table.py
@@ -1,0 +1,75 @@
+"""Add print queue table
+
+Revision ID: 40ec91ad7a74
+Revises: 3589a98a0c28
+Create Date: 2021-11-04 03:38:08.816882
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '40ec91ad7a74'
+down_revision = '3589a98a0c28'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import residue
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.create_table('print_job',
+    sa.Column('id', residue.UUID(), nullable=False),
+    sa.Column('attendee_id', residue.UUID(), nullable=False),
+    sa.Column('admin_id', residue.UUID(), nullable=False),
+    sa.Column('admin_name', sa.Unicode(), server_default='', nullable=False),
+    sa.Column('printer_id', sa.Unicode(), server_default='', nullable=False),
+    sa.Column('reg_station', sa.Integer(), nullable=True),
+    sa.Column('queued', residue.UTCDateTime(), nullable=True),
+    sa.Column('printed', residue.UTCDateTime(), nullable=True),
+    sa.Column('errors', sa.Unicode(), server_default='', nullable=False),
+    sa.Column('is_minor', sa.Boolean(), nullable=False),
+    sa.Column('json_data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.ForeignKeyConstraint(['admin_id'], ['admin_account.id'], name=op.f('fk_print_queue_admin_id_admin_account')),
+    sa.ForeignKeyConstraint(['attendee_id'], ['attendee.id'], name=op.f('fk_print_queue_attendee_id_attendee')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_print_queue'))
+    )
+
+
+def downgrade():
+    op.drop_table('print_job')

--- a/uber/api.py
+++ b/uber/api.py
@@ -1068,7 +1068,7 @@ class PrintJobLookup:
             return job.id
 
     @api_auth('api_update')
-    def print_job_complete(self, job_ids, complete_all=False):
+    def print_job_complete(self, job_ids=None, complete_all=False):
         """
         Marks print jobs as printed.
 
@@ -1081,11 +1081,11 @@ class PrintJobLookup:
         """
         with Session() as session:
             base_query = session.query(PrintJob).filter_by(printed=None)
-            job_ids = [id.strip() for id in job_ids.split(',')]
 
             if complete_all:
                 jobs = base_query.all()
             else:
+                job_ids = [id.strip() for id in job_ids.split(',')]
                 jobs = base_query.filter(PrintJob.id.in_(job_ids)).all()
 
             if not jobs:

--- a/uber/models/admin.py
+++ b/uber/models/admin.py
@@ -49,6 +49,7 @@ class AdminAccount(MagModel):
                     'ApiToken.revoked_time == None)')
 
     judge = relationship('IndieJudge', uselist=False, backref='admin_account')
+    print_requests = relationship('PrintJob', backref='admin_account')
 
     def __repr__(self):
         return '<{}>'.format(self.attendee.full_name)

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -423,6 +423,7 @@ class Attendee(MagModel, TakesPaymentMixin):
     # =========================
     times_printed = Column(Integer, default=0)
     print_pending = Column(Boolean, default=False)
+    print_requests = relationship('PrintJob', backref='attendee')
     
     # =========================
     # art show

--- a/uber/models/badge_printing.py
+++ b/uber/models/badge_printing.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from pytz import UTC
+from residue import CoerceUTF8 as UnicodeText, UTCDateTime, UUID
+from sqlalchemy.dialects.postgresql.json import JSONB
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.schema import ForeignKey
+from sqlalchemy.types import Boolean, Integer
+
+from uber.config import c
+from uber.models import MagModel
+from uber.models.types import DefaultColumn as Column, MultiChoice, utcnow
+
+
+__all__ = ['PrintJob']
+
+
+class PrintJob(MagModel):
+    attendee_id = Column(UUID, ForeignKey('attendee.id'))
+    admin_id = Column(UUID, ForeignKey('admin_account.id'))
+    admin_name = Column(UnicodeText) # Preserve admin's name in case their account is removed
+    printer_id = Column(UnicodeText)
+    reg_station = Column(Integer, nullable=True)
+    queued = Column(UTCDateTime, nullable=True, default=None)
+    printed = Column(UTCDateTime, nullable=True, default=None)
+    errors = Column(UnicodeText)
+    is_minor = Column(Boolean)
+    json_data = Column(MutableDict.as_mutable(JSONB), default={})

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -892,7 +892,7 @@ class Root:
                 params[key] = True
             if params[key] == "null":
                 params[key] = ""
-                
+
         attendee = session.attendee(params, allow_invalid=True)
 
         if attendee.is_new and (not attendee.first_name or not attendee.last_name):

--- a/uber/templates/api/reference.html
+++ b/uber/templates/api/reference.html
@@ -348,7 +348,7 @@
     <div class="row">
       <div class="col-sm-6 prose-column">
         {% if loop.first %}<h1>Live Examples</h1>{% endif %}
-        <h2>{{ service.name|title }} Service</h2>
+        <h2>{{ service.name|replace('_', ' ')|title }} Service</h2>
       </div>
     </div>
     <div class="row">

--- a/uber/templates/badge_printing/queued_badges.html
+++ b/uber/templates/badge_printing/queued_badges.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Badge Printing{% endblock %}
+{% block content %}
+
+<div class="panel panel-default">
+    <table class="table table-striped datatable">
+    <thead><tr>
+        <th>Created</th>
+        <th>Job ID</th>
+        <th>Full Name</th>
+        <th>Badge Name</th>
+        <th>Admin</th>
+        <th>Printer ID</th>
+        <th>Reg Station</th>
+        <th>Queued</th>
+        <th>Printed</th>
+        <th>Errors</th>
+        <th></th>
+    </tr></thead>
+    {% for badge in badges %}
+    <tr>
+    <td data-order="{{ badge.created.when }}">{{ badge.created.when|time_day_local }}</td>
+    <td>{{ badge.id }}</td>
+    <td data-order="{{ badge.attendee.full_name }}" data-search="{{ badge.attendee.full_name }}">
+        <a href="../registration/form?id={{ badge.attendee.id }}">{{ badge.attendee.full_name }}</a>
+    </td>
+    <td>
+        {{ badge.attendee.badge_printed_name }}
+    </td>
+    <td>{{ badge.admin_name }}</td>
+    <td>{{ badge.printer_id }}</td>
+    <td>{{ badge.reg_station }}</td>
+    <td id="queued_{{ badge.id }}" data-order="{{ badge.queued }}">{{ badge.queued|time_day_local|default("No", true) }}</td>
+    <td id="printed_{{ badge.id }}" data-order="{{ badge.printed }}">{{ badge.printed|time_day_local|default("No", true) }}</td>
+    <td id="errors_{{ badge.id }}">{{ badge.errors }}</td>
+    <td>
+        {% if badge.queued %}
+        <a class="btn btn-info ajax-link" href="mark_as_unsent?id={{ badge.id }}">Mark as Unsent</a>
+        {% endif %}
+        {% if not badge.printed %}
+        <a class="btn btn-success ajax-link" href="mark_as_printed?id={{ badge.id }}">Mark as Printed</a>
+        {% endif %}
+        {% if not badge.printed and not badge.errors %}
+        <a id="errors_{{ badge.id }}_link" class="btn btn-danger ajax-link" href="mark_as_invalid?id={{ badge.id }}">
+            Mark as Invalid
+        </a>
+        {% endif %}
+    </td>
+    </tr>
+    {% endfor %}
+</table>
+</div>
+
+<script type="text/javascript">
+    $('.ajax-link').on('click', function (event) {
+        var $link = $(this);
+        event.preventDefault();
+        toastr.clear();
+        $.ajax({
+            method: 'GET',
+            url: $link.attr('href'),
+            success: function (json) {
+                if (json.success) {
+                    toastr.success(json.message);
+                } else {
+                    toastr.error(json.message);
+                }
+                $link.hide()
+                if (json.queued) {
+                    $('#queued_' + json.id).html(json.queued);
+                }
+                if (json.printed) {
+                    $('#printed_' + json.id).html(json.printed);
+                    $('#errors_' + json.id + '_link').hide()
+                }
+                if (json.errors) {
+                    $('#errors_' + json.id).html(json.errors);
+                }
+            },
+            error: function () {
+                toastr.error('Unable to connect to server, please try again.');
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/uber/templates/badge_printing/queued_badges.html
+++ b/uber/templates/badge_printing/queued_badges.html
@@ -34,16 +34,16 @@
     <td id="printed_{{ badge.id }}" data-order="{{ badge.printed }}">{{ badge.printed|time_day_local|default("No", true) }}</td>
     <td id="errors_{{ badge.id }}">{{ badge.errors }}</td>
     <td>
-        {% if badge.queued %}
-        <a class="btn btn-info ajax-link" href="mark_as_unsent?id={{ badge.id }}">Mark as Unsent</a>
-        {% endif %}
         {% if not badge.printed %}
-        <a class="btn btn-success ajax-link" href="mark_as_printed?id={{ badge.id }}">Mark as Printed</a>
-        {% endif %}
-        {% if not badge.printed and not badge.errors %}
-        <a id="errors_{{ badge.id }}_link" class="btn btn-danger ajax-link" href="mark_as_invalid?id={{ badge.id }}">
-            Mark as Invalid
-        </a>
+            {% if badge.queued and not badge.errors %}
+            <a id="queued_{{ badge.id }}_link" class="btn btn-info ajax-link" href="mark_as_unsent?id={{ badge.id }}">Mark as Unsent</a>
+            {% endif %}
+            <a class="btn btn-success ajax-link" href="mark_as_printed?id={{ badge.id }}">Mark as Printed</a>
+            {% if not badge.errors %}
+            <a class="btn btn-danger ajax-link" href="mark_as_invalid?id={{ badge.id }}">
+                Mark as Invalid
+            </a>
+            {% endif %}
         {% endif %}
     </td>
     </tr>
@@ -71,10 +71,11 @@
                 }
                 if (json.printed) {
                     $('#printed_' + json.id).html(json.printed);
-                    $('#errors_' + json.id + '_link').hide()
+                    $link.parent('td').children().hide();
                 }
                 if (json.errors) {
                     $('#errors_' + json.id).html(json.errors);
+                    $('#queued_' + json.id + '_link').hide()
                 }
             },
             error: function () {

--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -8,6 +8,7 @@
 
 <div class="panel panel-default">
 <div class="panel-body">
+    {% include 'registration/queue_badge.html' %}
 <form method="post" action="form" class="form-horizontal">
 {{ csrf_token() }}
 <input type="hidden" name="id" value="{{ attendee.db_id }}" />

--- a/uber/templates/registration/queue_badge.html
+++ b/uber/templates/registration/queue_badge.html
@@ -1,0 +1,39 @@
+<form class="print-badge form-horizontal" method="post">
+    {{ csrf_token() }}
+    <input type="hidden" name="id" value="{{ attendee.id }}">
+    <div class="form-group">
+        <label for="printer_id" class="col-sm-3 control-label">Printer ID</label>
+        <div class="col-sm-6">
+            <input type="text" name="printer_id" class="form-control" value="{{ printer_id }}" />
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-9 col-sm-offset-3">
+            <button type="submit" class="btn btn-success">Queue for Printing</button>
+        </div>
+    </div>
+</form>
+
+<script type="text/javascript">
+$('.print-badge').on('submit', function (event) {
+    var $form = $(this);
+    event.preventDefault();
+    toastr.clear();
+    $.ajax({
+        method: 'POST',
+        url: '../badge_printing/add_job_to_queue',
+        data: $form.serialize(),
+        success: function (json) {
+            if (json.success) {
+            toastr.success(json.message);
+            } else {
+            toastr.error(json.message);
+            }
+        },
+        error: function () {
+            toastr.error('Unable to connect to server, please try again.');
+        }
+    });
+});
+</script>


### PR DESCRIPTION
This is the first major step of adding support for a printer server (https://github.com/MidwestFurryFandom/rams/issues/460). It includes the API endpoints and enough front-end changes for basic testing.

To test, browse to /registration/ and set your Reg Station number using the button toggle near the top:
![image](https://user-images.githubusercontent.com/7198215/140593989-497a71d5-6525-493d-9587-25d86b81f072.png)

Then open any reasonably-complete Attendee's form, enter any string for the printer ID, and click "Queue for Printing":
![image](https://user-images.githubusercontent.com/7198215/140594015-6618ea17-f5bc-45f0-893a-b3e7b9fdbad0.png)

You can see print jobs using the new page at /badge_printing/queued_badges. Browse to /api/reference and find the "Print Job Service" section to test the API endpoints.