### PR TITLE
Add metadata to print job API

### DIFF
--- a/uber/templates/badge_printing/queued_badges.html
+++ b/uber/templates/badge_printing/queued_badges.html
@@ -25,7 +25,7 @@
         <a href="../registration/form?id={{ badge.attendee.id }}">{{ badge.attendee.full_name }}</a>
     </td>
     <td>
-        {{ badge.attendee.badge_printed_name }}
+        {{ badge.json_data['badge_printed_name'] }}
     </td>
     <td>{{ badge.admin_name }}</td>
     <td>{{ badge.printer_id }}</td>


### PR DESCRIPTION
This should finish the API for print jobs, barring anything found in testing. Includes more metadata in pending_jobs, the ability to select jobs by printer_id, some improvements to print_job_error and print_job_complete, and an update call that runs if restart is passed to pending_jobs.