### PR TITLE
Always render badge printed name field

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -720,8 +720,7 @@
     </div>
   {% endif %}
 {% else %}
-  {% if attendee.badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.amount_extra >= c.SUPPORTER_LEVEL %}
-    <div class="form-group">
+    <div class="form-group badge-row"{% if attendee.badge_type not in c.PREASSIGNED_BADGE_TYPES and attendee.amount_extra < c.SUPPORTER_LEVEL %} style="display:none"{% endif %}>
       <label for="badge_printed_name" class="col-sm-3 control-label">Name Printed on Badge</label>
       {% call macros.read_only_if(read_only, attendee.badge_printed_name) %}
         <div class="col-sm-6">
@@ -730,7 +729,6 @@
       {% endcall %}
     </div>
   {% endif %}
-{% endif %}
 {% endif %}
 {% endset %}
 


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/458. We were only rendering the printed name field on the admin form in certain cases -- now we just keep it hidden under those same cases, so the MFF plugin can unhide it like it does with attendee-facing pages.