### PR TITLE
Mark unapproved dealers as not ready to check in

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -990,6 +990,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
         if self.badge_status not in [c.COMPLETED_STATUS, c.NEW_STATUS]:
             return "Badge status is {}".format(self.badge_status_label)
+
+        if self.group and self.group.is_dealer and self.group.status != c.APPROVED:
+            return "Unapproved dealer"
         
         if self.placeholder:
             return "Placeholder badge"


### PR DESCRIPTION
Fixes https://github.com/MidwestFurryFandom/rams/issues/372 -- the check we use for sending the QR code email is the same as the check we use for people who can check in, so this should prevent any non-approved dealers from getting this email.