### PR TITLE
Fix several bugs with API attendee creation

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -579,7 +579,6 @@ class AttendeeLookup:
             attendee.apply(params, restricted=False)
             session.add(attendee)
 
-            # Duplicates functionality on the admin form that makes staff badges need not pay
             # Staff (not volunteers) also almost never need to pay by default
             if (attendee.staffing and c.VOLUNTEER_RIBBON not in attendee.ribbon_ints) and 'paid' not in params:
                 attendee.paid = c.NEED_NOT_PAY

--- a/uber/api.py
+++ b/uber/api.py
@@ -561,9 +561,9 @@ class AttendeeLookup:
         <pre>{"placeholder": "yes", "legal_name": "First Last", "cellphone": "5555555555"}</pre>
         """
         with Session() as session:
-            attendee_query = session.query(Attendee).filter(Attendee.first_name.ilike("first_name"),
-                                                            Attendee.last_name.ilike("last_name"),
-                                                            Attendee.email.ilike("email@example.com"))
+            attendee_query = session.query(Attendee).filter(Attendee.first_name.ilike(first_name),
+                                                            Attendee.last_name.ilike(last_name),
+                                                            Attendee.email.ilike(email))
 
             if attendee_query.first():
                 raise HTTPError(400, 'An attendee with this name and email address already exists')
@@ -572,22 +572,22 @@ class AttendeeLookup:
 
             if params:
                 for key, val in params.items():
-                    params[key] = _parse_if_datetime(key, val)
-                    params[key] = _parse_if_boolean(key, val)
+                    if val != "":
+                        params[key] = _parse_if_datetime(key, val)
+                        params[key] = _parse_if_boolean(key, val)
 
             attendee.apply(params, restricted=False)
             session.add(attendee)
+
+            # Duplicates functionality on the admin form that makes staff badges need not pay
+            # Staff (not volunteers) also almost never need to pay by default
+            if (attendee.staffing and c.VOLUNTEER_RIBBON not in attendee.ribbon_ints) and 'paid' not in params:
+                attendee.paid = c.NEED_NOT_PAY
 
             message = check(attendee)
             if message:
                 session.rollback()
                 raise HTTPError(400, message)
-
-            # Duplicates functionality on the admin form that makes placeholder badges need not pay
-            # Staff (not volunteers) also almost never need to pay by default
-            if (attendee.placeholder or
-                    attendee.staffing and c.VOLUNTEER_RIBBON not in attendee.ribbon_ints) and 'paid' not in params:
-                attendee.paid = c.NEED_NOT_PAY
 
             return attendee.id
 

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -835,7 +835,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def total_cost(self):
-        return self.default_cost + self.amount_extra
+        return self.default_cost + (self.amount_extra or 0)
 
     @property
     def total_donation(self):

--- a/uber/site_sections/devtools.py
+++ b/uber/site_sections/devtools.py
@@ -125,7 +125,6 @@ class Root:
                 elif isinstance(col.type, Integer):
                     val = int(val)
                 elif isinstance(col.type, JSONB):
-                    val = val.replace("'", '"') # Temporary fix for Access Groups -- remove after SuperMAG 2021
                     val = json.loads(val)
 
                 # now that we've converted val to whatever it actually needs to be, we


### PR DESCRIPTION
Fixes the following issues:
- not actually checking for duplicate attendee name+email (debug values were left in)
- blowing up when given empty strings for some fields (we now skip any empty fields)
- blowing up on JSONB fields (we now parse them in MagModel.apply)
- model checks blowing up when labels were given instead of literal Choice/MultiChoice values (we now also parse labels in MagModel.apply, not just when actually saving to the DB)
- two bugs in Attendee.total_cost, one where an exception wasn't being thrown correctly and another where amount_extra is set to None by MagModel.apply and then the total_cost property expects it to always be an integer, again blowing up model checks