### PR TITLE
Add workflow for printing badges during check-in

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1247,8 +1247,8 @@ class Session(SessionManager):
             
             if not attendee.birthdate:
                 errors.append("Attendee is missing a date of birth.")
-            elif attendee.age_group_conf['val'] == c.AGE_UNKNOWN:
-                errors.append("Age group not recognized.")
+            elif not attendee.age_now_or_at_con:
+                errors.append("Attendee's date of birth is not recognized as a date.")
 
             attendee_fields = attendee.to_dict(fields)
 
@@ -1268,7 +1268,7 @@ class Session(SessionManager):
                                  printer_id = printer_id,
                                  reg_station = reg_station)
 
-            if attendee.age_group_conf['val'] in [c.UNDER_21, c.OVER_21]:
+            if attendee.age_now_or_at_con >= 18:
                 print_job.is_minor = False
             else:
                 print_job.is_minor = True

--- a/uber/templates/badge_printing/print_jobs.html
+++ b/uber/templates/badge_printing/print_jobs.html
@@ -1,0 +1,88 @@
+{% if badges|length == c.ROW_LOAD_LIMIT %}
+<div class="panel panel-body">
+There is a limit of <strong>{{ c.ROW_LOAD_LIMIT }}</strong> print jobs per view. Please use another view to see complete print jobs.
+</div>
+{% endif %}
+
+<div class="panel panel-default">
+    <table class="table table-striped datatable">
+    <thead><tr>
+        <th>Created</th>
+        <th>Job ID</th>
+        <th>Full Name</th>
+        <th>Badge Name</th>
+        <th>Admin</th>
+        <th>Printer ID</th>
+        <th>Reg Station</th>
+        <th>Queued</th>
+        <th>Printed</th>
+        <th>Errors</th>
+        <th></th>
+    </tr></thead>
+    {% for badge in badges %}
+    <tr>
+    <td data-order="{{ badge.created.when }}">{{ badge.created.when|time_day_local }}</td>
+    <td>{{ badge.id }}</td>
+    <td data-order="{{ badge.attendee.full_name }}" data-search="{{ badge.attendee.full_name }}">
+        <a href="../registration/form?id={{ badge.attendee.id }}">{{ badge.attendee.full_name }}</a>
+    </td>
+    <td>
+        {{ badge.json_data['badge_printed_name'] }}
+    </td>
+    <td>{{ badge.admin_name }}</td>
+    <td>{{ badge.printer_id }}</td>
+    <td>{{ badge.reg_station }}</td>
+    <td id="queued_{{ badge.id }}" data-order="{{ badge.queued }}">{{ badge.queued|time_day_local|default("No", true) }}</td>
+    <td id="printed_{{ badge.id }}" data-order="{{ badge.printed }}">{{ badge.printed|time_day_local|default("No", true) }}</td>
+    <td id="errors_{{ badge.id }}">{{ badge.errors }}</td>
+    <td>
+        {% if not badge.printed %}
+            {% if badge.queued and not badge.errors %}
+            <a id="queued_{{ badge.id }}_link" class="btn btn-info ajax-link" href="mark_as_unsent?id={{ badge.id }}">Mark as Unsent</a>
+            {% endif %}
+            <a class="btn btn-success ajax-link" href="mark_as_printed?id={{ badge.id }}">Mark as Printed</a>
+            {% if not badge.errors %}
+            <a class="btn btn-danger ajax-link" href="mark_as_invalid?id={{ badge.id }}">
+                Mark as Invalid
+            </a>
+            {% endif %}
+        {% endif %}
+    </td>
+    </tr>
+    {% endfor %}
+</table>
+</div>
+
+<script type="text/javascript">
+    $('.ajax-link').on('click', function (event) {
+        var $link = $(this);
+        event.preventDefault();
+        toastr.clear();
+        $.ajax({
+            method: 'GET',
+            url: $link.attr('href'),
+            success: function (json) {
+                if (json.success) {
+                    toastr.success(json.message);
+                } else {
+                    toastr.error(json.message);
+                }
+                $link.hide()
+                if (json.queued) {
+                    $('#queued_' + json.id).html(json.queued);
+                }
+                if (json.printed) {
+                    $('#printed_' + json.id).html(json.printed);
+                    $link.parent('td').children().hide();
+                }
+                if (json.errors) {
+                    $('#errors_' + json.id).html(json.errors);
+                    $('#queued_' + json.id + '_link').hide()
+                }
+            },
+            error: function () {
+                toastr.error('Unable to connect to server, please try again.');
+            }
+        });
+    });
+</script>

--- a/uber/templates/badge_printing/queued_badges.html
+++ b/uber/templates/badge_printing/queued_badges.html
@@ -1,87 +1,30 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% block title %}Badge Printing{% endblock %}
+{% block title %}Print Jobs{% endblock %}
 {% block content %}
-
-<div class="panel panel-default">
-    <table class="table table-striped datatable">
-    <thead><tr>
-        <th>Created</th>
-        <th>Job ID</th>
-        <th>Full Name</th>
-        <th>Badge Name</th>
-        <th>Admin</th>
-        <th>Printer ID</th>
-        <th>Reg Station</th>
-        <th>Queued</th>
-        <th>Printed</th>
-        <th>Errors</th>
-        <th></th>
-    </tr></thead>
-    {% for badge in badges %}
-    <tr>
-    <td data-order="{{ badge.created.when }}">{{ badge.created.when|time_day_local }}</td>
-    <td>{{ badge.id }}</td>
-    <td data-order="{{ badge.attendee.full_name }}" data-search="{{ badge.attendee.full_name }}">
-        <a href="../registration/form?id={{ badge.attendee.id }}">{{ badge.attendee.full_name }}</a>
-    </td>
-    <td>
-        {{ badge.json_data['badge_printed_name'] }}
-    </td>
-    <td>{{ badge.admin_name }}</td>
-    <td>{{ badge.printer_id }}</td>
-    <td>{{ badge.reg_station }}</td>
-    <td id="queued_{{ badge.id }}" data-order="{{ badge.queued }}">{{ badge.queued|time_day_local|default("No", true) }}</td>
-    <td id="printed_{{ badge.id }}" data-order="{{ badge.printed }}">{{ badge.printed|time_day_local|default("No", true) }}</td>
-    <td id="errors_{{ badge.id }}">{{ badge.errors }}</td>
-    <td>
-        {% if not badge.printed %}
-            {% if badge.queued and not badge.errors %}
-            <a id="queued_{{ badge.id }}_link" class="btn btn-info ajax-link" href="mark_as_unsent?id={{ badge.id }}">Mark as Unsent</a>
-            {% endif %}
-            <a class="btn btn-success ajax-link" href="mark_as_printed?id={{ badge.id }}">Mark as Printed</a>
-            {% if not badge.errors %}
-            <a class="btn btn-danger ajax-link" href="mark_as_invalid?id={{ badge.id }}">
-                Mark as Invalid
-            </a>
-            {% endif %}
-        {% endif %}
-    </td>
-    </tr>
-    {% endfor %}
-</table>
+<strong>View print jobs:</strong>
+<div class="btn-group" style="padding-bottom:10px;">
+<button class="btn btn-default job-types" id="pending" onClick="loadPrintJobs('pending')">Pending</button>
+<button class="btn btn-default job-types" id="not_printed" onClick="loadPrintJobs('not_printed')">Waiting to Print</button>
+<button class="btn btn-default job-types" id="errors" onClick="loadPrintJobs('errors')">With Errors</button>
+<button class="btn btn-default job-types" id="created" onClick="loadPrintJobs('created')">Created By You</button>
+<button class="btn btn-default job-types" id="printed" onClick="loadPrintJobs('printed')">Printed</button>
 </div>
-
+<div id="print_jobs"></div>
 <script type="text/javascript">
-    $('.ajax-link').on('click', function (event) {
-        var $link = $(this);
-        event.preventDefault();
-        toastr.clear();
-        $.ajax({
-            method: 'GET',
-            url: $link.attr('href'),
-            success: function (json) {
-                if (json.success) {
-                    toastr.success(json.message);
-                } else {
-                    toastr.error(json.message);
-                }
-                $link.hide()
-                if (json.queued) {
-                    $('#queued_' + json.id).html(json.queued);
-                }
-                if (json.printed) {
-                    $('#printed_' + json.id).html(json.printed);
-                    $link.parent('td').children().hide();
-                }
-                if (json.errors) {
-                    $('#errors_' + json.id).html(json.errors);
-                    $('#queued_' + json.id + '_link').hide()
-                }
-            },
-            error: function () {
-                toastr.error('Unable to connect to server, please try again.');
-            }
-        });
-    });
+var loadPrintJobs = function(flag) {
+  $('.job-types').removeClass('btn-primary btn-default').addClass('btn-default');
+  $('#' + flag).addClass('btn-primary').removeClass('btn-default');
+    $('#print_jobs').load('../badge_printing/print_jobs?flag=' + flag, function(){
+      if ($('#print_jobs').length) {
+          $(window).trigger( 'runJavaScript' );
+      } else {
+          // We got redirected -- likely to the login page -- so load it properly
+          toastr.error("Loading failed.");
+          window.location.hash = ""; // prevent refresh loops
+          window.location.reload();
+      }
+      });
+    }
+$('#pending').click();
 </script>
 {% endblock %}

--- a/uber/templates/check_in.html
+++ b/uber/templates/check_in.html
@@ -6,12 +6,18 @@
 </div>
 
 <script type="text/javascript">
-checkInModal = $('#checkin_modal')
+checkInModal = $('#checkin_modal');
+reg_station = {{ reg_station|default(0, true) }};
+printer_default_id = "{{ printer_default_id }}";
+printer_minor_id = "{{ printer_minor_id }}";
+badge_printing_enabled = {{ c.BADGE_PRINTING_ENABLED|yesno("true,false") }};
 
-var loadCheckInModal = function (attendeeID) {
-    checkInModal.modal({show:true});
+var loadCheckInFormModal = function (attendeeID, printerID='') {
     $('#checkin_modal .modal-content').load('../registration/check_in_form?id=' + attendeeID, function() {
         if ($('.check-in').length) {
+            if (printerID) {
+                $.field('printer_id').val(printerID);
+            }
             checkInModal.find('input.date').datetextentry({
                 field_order: 'MDY',
                 show_tooltips: false
@@ -24,6 +30,22 @@ var loadCheckInModal = function (attendeeID) {
             checkInModal.modal('hide');
         }
     });
+}
+
+var loadCheckInModal = function (attendeeID) {
+    checkInModal.modal({show:true});
+    
+    if (badge_printing_enabled && (!reg_station || !printer_default_id || !printer_minor_id)) {
+    $('#checkin_modal .modal-content').load('../registration/printer_id_form?id=' + attendeeID, function() {
+        if ($('.printer-id').length) {
+        } else {
+            toastr.error("Form loading failed.");
+            checkInModal.modal('hide');
+        }
+        });
+    } else {
+        loadCheckInFormModal(attendeeID);
+    }
 };
 
 // Hide modal on Esc keydown
@@ -41,15 +63,15 @@ var checkIn = function (attendeeID) {
         data: $("#check_in_form_" + attendeeID).serialize(),
         success: function (json) {
             toastr.clear();
-            checkInModal.modal('hide');
             var message = json.message;
             if (json.success) {
+                checkInModal.modal('hide');
                 message += ' &nbsp; <a href="#" onClick="undoCheckIn(\'' + attendeeID + '\', ' + json.pre_badge + ') ; return false">Undo</a>';
                 $('#paid_' + attendeeID).html(json.paid);
                 $('#cin_' + attendeeID).html(json.checked_in);
                 $('#age_' + attendeeID).parent().html(json.age_group);
                 $('#num_' + attendeeID).parent().html(json.badge);
-                toastr.info(message);
+                toastr.success(message);
             } else {
                 toastr.error(message);
             }

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1397,10 +1397,8 @@ $(window).on("runJavaScript", function () {
     {% for manager in attendee.managers %}
       {% if not loop.first %} / {% endif %}{{ manager.email }}
       {% if manager.attendees|length > 1 %}
-      ({%- for managed_attendee in manager.attendees -%}
-          {%- if managed_attendee.id != attendee.id -%}
-          {{ managed_attendee|form_link }}{% if not loop.last %} / {% endif %}
-          {%- endif -%}
+      ({%- for managed_attendee in manager.attendees|selectattr('id','!=',attendee.id) -%}
+        {% if not loop.first %} / {% endif %}{{ managed_attendee|form_link }}
         {%- endfor -%})
       {% endif %}
     {% else %}

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -157,7 +157,7 @@
                   <td>Can't checkin ({{ attendee.is_not_ready_to_checkin }})</td>
                 {% else %}
                   <td id="cin_{{ attendee.id }}">
-                    <button class="attendee-checkin" data-attendee-id="{{ attendee.id }}">Check In</button>
+                    <button class="attendee-checkin btn btn-sm btn-success" data-attendee-id="{{ attendee.id }}">Check In</button>
                   </td>
                 {% endif %}
               {% endif %}

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -66,7 +66,7 @@ $("form[action='mark_as_paid']").submit(function (e) {
             toastr.clear();
             var message = json.message;
             if (json.success) {
-                toastr.info(message);
+                toastr.success(message);
                 loadCheckInForm();
             } else {
                 toastr.error(message);
@@ -85,7 +85,7 @@ $('#stripe_frame').load(function() {
         toastr.clear();
         var response = $.parseJSON(responseText);
         if (response['success'] == true) {
-            toastr.info(response['message']);
+            toastr.success(response['message']);
             loadCheckInForm();
         } else {
             toastr.error('', response['message'], {timeOut: 1000});
@@ -240,12 +240,21 @@ $().ready(function() {
         <div class="col-sm-6"><label style="font-weight:normal;"><input type="checkbox" name="got_merch" value="1" /> Yes, this attendee has received their merch</label></div>
       </div>
     {% endif %}
+    {% if c.BADGE_PRINTING_ENABLED %}
+      <div class="form-group">
+        <label for="printer_id" class="col-sm-3 control-label"><strong>Printer ID</strong></label>
+        <div class="col-sm-6"><input type="text" class="form-control" name="printer_id" /></div>
+      </div>
+    {% endif %}
     {% endblock checkin_fields %}
 </form>
 </div>
 <div class="modal-footer">
   <div class="form-group">
   <div class="pull-right">
+        {% if c.BADGE_PRINTING_ENABLED %}
+        <button type="button" onClick="printBadge('{{ attendee.id }}')" class="btn btn-success">Save & Print Badge</button>
+        {% endif %}
       <button type="button" onClick="checkIn('{{ attendee.id }}')" class="btn btn-primary">Save & Check In</button>
 {% endif %}
    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
@@ -254,3 +263,49 @@ $().ready(function() {
   </div>
  
 </div>
+{% if c.BADGE_PRINTING_ENABLED %}
+<script type="text/javascript">
+    loadMinorCheckForm = function (attendeeID, printerID) {
+        $('#checkin_modal .modal-content').load(
+            '../registration/minor_check_form?attendee_id=' + attendeeID + '&printer_id=' + printerID, function() {
+        if ($('.minor-check-id').length) {
+        } else {
+            toastr.error("Form loading failed.");
+            loadCheckInFormModal(attendeeID);
+        }
+        });
+    }
+    var printBadge = function (attendeeID) {
+        $.ajax({
+            method: 'POST',
+            url: '../registration/print_badge',
+            dataType: 'json',
+            data: $("#check_in_form_" + attendeeID).serialize(),
+            success: function (json) {
+                toastr.clear();
+                var message = json.message;
+                if (json.success) {
+                    if (json.minor_check) {
+                        loadMinorCheckForm(attendeeID, $.val('printer_id'));
+                    } else {
+                        toastr.success(message);
+                        loadCheckInFormModal(attendeeID);
+                    }
+                } else {
+                    toastr.error(message);
+                }
+            },
+            error: function () {
+                toastr.error('Unable to connect to server, please try again.');
+            }
+        });
+    };
+
+    age = {{ attendee.age_now_or_at_con|default(0, true)}};
+    if (age < 18) {
+        $.field('printer_id').val(printer_minor_id);
+    } else if (age >= 18) {
+        $.field('printer_id').val(printer_default_id);
+    }
+</script>
+{% endif %}

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -199,7 +199,7 @@
                         <td>Can't checkin (Attendee owes {{ attendee.amount_unpaid|format_currency }})</td>
                       {% else %}
                         <td id="cin_{{ attendee.id }}">
-                            <button class="attendee-checkin btn-sm btn-success" data-attendee-id="{{ attendee.id }}" onClick="loadCheckInModal('{{ attendee.id }}')">Check In</button>
+                            <button class="attendee-checkin btn btn-sm btn-success" data-attendee-id="{{ attendee.id }}" onClick="loadCheckInModal('{{ attendee.id }}')">Check In</button>
                         </td>
                       {% endif %}
                     {% endif %}

--- a/uber/templates/registration/minor_check_form.html
+++ b/uber/templates/registration/minor_check_form.html
@@ -1,0 +1,68 @@
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal">&times;</button>
+    <h4 class="modal-title">Please Load Minor Badge Stock</h4>
+    Please take a moment to load a blank badge from the minor badge stock onto printer "{{ printer_id }}" before printing this badge.
+    </div>
+    <div class="modal-body">
+        <form action="/" role="form" class="form-horizontal minor-check-id">
+        <div class="form-group">
+            <label for="printer_id" class="col-sm-3 control-label">Printer ID</label>
+            <div class="col-sm-6"><input type="text" class="form-control" onKeyUp="changeButtonLabel()" value="{{ printer_id }}" name="printer_id" /></div>
+        </div>
+  </form>
+  </div>
+  <div class="modal-footer">
+    <div class="form-group">
+    <div class="pull-right">
+     <button type="button" id="completeMinorCheckButton" onClick="completeMinorCheck('{{ attendee_id }}')" class="btn"></button>
+     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+    </div>
+    </div>
+    </div>
+   
+  </div>
+  
+<script type="text/javascript">
+    var changeButtonLabel = function () {
+        var old_printer_id = "{{ printer_id }}";
+        if ($.val('printer_id') != old_printer_id) {
+            $('#completeMinorCheckButton')[0].innerHTML = "Switch Badge Printers Instead";
+            $('#completeMinorCheckButton').removeClass('btn-success');
+            $('#completeMinorCheckButton').addClass('btn-warning');
+        } else {
+            $('#completeMinorCheckButton')[0].innerHTML = "I've Loaded the Minor Badge Stock";
+            $('#completeMinorCheckButton').removeClass('btn-warning');
+            $('#completeMinorCheckButton').addClass('btn-success');
+        }
+    }
+    changeButtonLabel();
+    var completeMinorCheck = function (attendeeID) {
+        var old_printer_id = "{{ printer_id }}";
+        if ($.val('printer_id') != old_printer_id) {
+            loadCheckInFormModal(attendeeID, $.val('printer_id'));
+        } else {
+            $.ajax({
+            method: 'GET',
+            url: '../registration/complete_minor_check',
+            dataType: 'json',
+            data: {
+                attendee_id: attendeeID,
+                printer_id: $.val('printer_id')
+            },
+            success: function (json) {
+                toastr.clear();
+                var message = json.message;
+                if (json.success) {
+                    toastr.success(message);
+                    loadCheckInFormModal(attendeeID);
+                } else {
+                    toastr.error(message);
+                }
+            },
+            error: function () {
+                toastr.error('Unable to connect to server, please try again.');
+            }
+            });
+        }
+    };
+</script>

--- a/uber/templates/registration/printer_id_form.html
+++ b/uber/templates/registration/printer_id_form.html
@@ -1,0 +1,58 @@
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal">&times;</button>
+    <h4 class="modal-title">Please Set Default Printer IDs</h4>
+    </div>
+    <div class="modal-body">
+  <form action="/" id="printer_id_form" role="form" class="form-horizontal printer-id">
+        {{ csrf_token() }}
+        <div class="form-group">
+            <label for="reg_station" class="col-sm-3 control-label">Reg Station #</label>
+            <div class="col-sm-6"><input type="number" class="form-control" value="{{ reg_station }}" name="reg_station" /></div>
+        </div>
+        <div class="form-group">
+            <label for="printer_default_id" class="col-sm-3 control-label">Default Printer ID</label>
+            <div class="col-sm-6"><input type="text" class="form-control" value="{{ printer_default_id }}" name="printer_default_id" /></div>
+        </div>
+        <div class="form-group">
+            <label for="printer_minor_id" class="col-sm-3 control-label">Default Minor Printer ID</label>
+            <div class="col-sm-6"><input type="text" class="form-control" value="{{ printer_minor_id }}" name="printer_minor_id" /></div>
+        </div>
+  </form>
+  </div>
+  <div class="modal-footer">
+    <div class="form-group">
+    <div class="pull-right">
+        <button type="button" onClick="setPrinterIDs('{{ attendee_id }}')" class="btn btn-primary">Set Printer IDs</button>
+     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+    </div>
+    </div>
+    </div>
+   
+  </div>
+  
+<script type="text/javascript">
+    var setPrinterIDs = function (attendeeID) {
+        $.ajax({
+            method: 'POST',
+            url: '../registration/set_printer_ids',
+            dataType: 'json',
+            data: $("#printer_id_form").serialize(),
+            success: function (json) {
+                toastr.clear();
+                var message = json.message;
+                if (json.success) {
+                    toastr.success(message);
+                    reg_station = json.reg_station;
+                    printer_default_id = json.printer_default_id;
+                    printer_minor_id = json.printer_minor_id;
+                    loadCheckInFormModal(attendeeID);
+                } else {
+                    toastr.error(message);
+                }
+            },
+            error: function () {
+                toastr.error('Unable to connect to server, please try again.');
+            }
+        });
+    };
+</script>


### PR DESCRIPTION
The second half of https://github.com/MidwestFurryFandom/rams/issues/460. Adds a set of modals that guide admins through setting their default printer and minor printer IDs, printing badges, and switching out badge stock if they're printing minor badges on their default printer.

Here's the basic workflow:
1. The admin browses to People > Attendees, searches for an attendee by first name/last name (or even better, QR code) then clicks the green Check In button seen here: 
![image](https://user-images.githubusercontent.com/7198215/141601722-c1033a02-8cce-4031-8501-238cc62f0f07.png)
2. A modal pops up prompting the admin for a reg station number (note: MUST be an integer), a default printer ID, and a default printer ID for attendees under 18. These values are per-session and the reg station number should be unique to each check-in station: 
![image](https://user-images.githubusercontent.com/7198215/141601751-9be89b95-8dbf-49bf-b6ba-b9bfd8ad4345.png)
3. After entering this information, the admin is presented with the check-in modal, where they can edit some information (including the printer ID). The admin should confirm the attendee's DOB and printed badge name, then click "Save & Print" to send the badge to the printer:
![image](https://user-images.githubusercontent.com/7198215/141601790-12916e8f-ad0e-4e96-860e-a91945dae23f.png)
4. After the print job is sent, the admin can save & check in the attendee. They can check in future attendees without having to resubmit the default printer IDs. If they log out and back in, they should be prompted for the default IDs again.
5. If for some reason you want to force resetting the default printer IDs, you can use the "Set At-Door Reg Station" button at the top of the Attendees page to set your reg station to 0 and click Save: 
![image](https://user-images.githubusercontent.com/7198215/141601927-9f0da7f4-8c35-47bd-bbb2-4ce4bfa5235b.png)
This is not considered a valid reg station number, so the modal from step 2 will reopen the next time you start the check-in process for an attendee.


There's a second workflow which can be triggered by a few things:
- The admin sets the default printer and default minor printer IDs to be the same because they are using a single printer.
- The admin sets the printer ID for an under-18 attendee to the same as the default (i.e., non-minor) printer ID.
- The admin changes an attendee's birthdate, changing their age from over 18 to under 18, and doesn't update the printer ID before trying to print.*

1. In this workflow, starting from step 3 above:
![image](https://user-images.githubusercontent.com/7198215/141602019-42792c54-98bc-4f19-9ea4-e2c0bbeecd1a.png)
2.
- If there are other badges waiting to print, the admin gets an error message: 
![image](https://user-images.githubusercontent.com/7198215/141602052-ddb0729c-c4c2-49f6-b31d-51f12c90992b.png)
- Otherwise, the admin is presented with a new pop-up prompting them to load minor badge stock onto the printer: 
![image](https://user-images.githubusercontent.com/7198215/141602078-07dcdfbf-448d-4d25-8d42-2c893bf87160.png)
3. The admin can confirm the pop-up OR change the printer ID: 
![image](https://user-images.githubusercontent.com/7198215/141602091-5b258ced-0109-4f78-8644-3c432274d935.png)
4.
- If the admin confirms the pop-up, the badge is queued and the check-in form is reloaded.
- If instead they opted to change the printer ID, the check-in form is reloaded with the new printer ID preloaded, and they can print from there: 
![image](https://user-images.githubusercontent.com/7198215/141602125-9091e2af-563c-4ace-bd93-d7ee32747a43.png)


By the way, once the Reg Station number is set, an admin can take payments through the check-in modal. Much like how the printer ID selection modal pops up before the check-in modal loads, a payment modal will appear for attendees who owe money, allowing you to collect payment or mark them as paid: 
![image](https://user-images.githubusercontent.com/7198215/141602286-aede07c9-bdb2-49ad-ae0f-ad3e4a4ca964.png)


*We use a plugin to handle our date of birth input, and unfortunately I was not able to get this particular plugin to let me detect changes on the fly.