### PR TITLE
Let admins see invalid badges

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -2008,7 +2008,8 @@ def _attendee_validity_check():
     def with_validity_check(self, *args, **kwargs):
         allow_invalid = kwargs.pop('allow_invalid', False)
         attendee = orig_getter(self, *args, **kwargs)
-        if not allow_invalid and not attendee.is_new and attendee.badge_status == c.INVALID_STATUS:
+        if not allow_invalid and not attendee.is_new and \
+           not self.current_admin_account and not attendee.badge_status == c.INVALID_STATUS:
             raise HTTPRedirect('../preregistration/invalid_badge?id={}', attendee.id)
         else:
             return attendee


### PR DESCRIPTION
The system keeps redirecting admins to an "invalid badge" page inappropriately anytime I forget to specify allow_invalid=True, so now we just check to see if they're a logged in admin before redirecting someone.