### PR TITLE
Enable check-in buttons for unpaid attendees

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -62,7 +62,7 @@ def check_atd(func):
 
 @all_renderable()
 class Root:
-    def index(self, session, message='', page='0', search_text='', uploaded_id='', order='last_first', invalid=''):
+    def index(self, session, message='', page='0', search_text='', uploaded_id='', order='last_first', invalid='', reset_printers=False):
         # DEVELOPMENT ONLY: it's an extremely convenient shortcut to show the first page
         # of search results when doing testing. it's too slow in production to do this by
         # default due to the possibility of large amounts of reg stations accessing this
@@ -96,6 +96,11 @@ class Root:
 
         pages = range(1, int(math.ceil(count / 100)) + 1)
         attendees = attendees[-100 + 100*page: 100*page] if page else []
+
+        if reset_printers:
+            cherrypy.session['printer_default_id'] = ''
+            cherrypy.session['printer_minor_id'] = ''
+            message = "Default Printer IDs reset."
 
         return {
             'message':        message if isinstance(message, str) else message[-1],

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -198,7 +198,7 @@
                     {% elif attendee.is_not_ready_to_checkin %}
                         <td>Can't checkin ({{ attendee.is_not_ready_to_checkin }})</td>
                     {% else %}
-                      {% if not reg_station and attendee.amount_unpaid %}
+                      {% if not reg_station and not c.BADGE_PRINTING_ENABLED and attendee.amount_unpaid %}
                         <td>Can't checkin (Attendee owes {{ attendee.amount_unpaid|format_currency }})</td>
                       {% else %}
                         <td id="cin_{{ attendee.id }}">

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -94,7 +94,8 @@
     <div class="col-xs-12">
         <span style="margin-right: 15px;">{{ attendee_count }} Attendee{{ attendee_count|pluralize }}</span>
         <span style="margin-right: 15px;"><span id="checkin_count">{{ checkin_count }}</span> Checked In</span>
-        {% if printer_minor_id %}<span class="pull-right">Minor Printer: {{ printer_minor_id }}</span>{% endif %}
+        {% if c.BADGE_PRINTING_ENABLED %}<span class="pull-right" style="margin-right: 15px;"><a href="index?order={{ order }}&page={{ page }}&search_text={{ search_text|urlencode }}&reset_printers=True">Reset Default Printer IDs</a></span>{% endif %}
+        {% if printer_minor_id %}<span class="pull-right" style="margin-right: 15px;">Minor Printer: {{ printer_minor_id }}</span>{% endif %}
         {% if printer_default_id %}<span class="pull-right" style="margin-right: 15px;">Standard Printer: {{ printer_default_id }}</span>{% endif %}
         {% if reg_station %}<span class="pull-right" style="margin-right: 15px;">Reg station #: {{ reg_station }}</span>{% endif %}
         {% if c.HAS_REG_ADMIN_ACCESS %}


### PR DESCRIPTION
The index page only shows check-in buttons for unpaid attendees if the Reg Station # is set. However, for events with badge printing, the reg station # gets set inside the check-in modal. To make things less confusing, we now just display the check-in button for unpaid attendees from the start.