### PR TITLE
Hide payment alert if you literally just took payment

### DIFF
--- a/uber/templates/registration/attendee_pending_warning.html
+++ b/uber/templates/registration/attendee_pending_warning.html
@@ -1,5 +1,5 @@
 {% if not attendee.amount_unpaid and attendee.paid in [c.NOT_PAID, c.PENDING] %}
-<div class="alert alert-warning">
+<div class="alert alert-warning" id="pending_paid_warning">
     <p><strong>This attendee is not marked as paid.</strong></p>
     <p>This could be because:
         <ul>

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -315,7 +315,11 @@ $().ready(function() {
                 var message = json.message;
                 if (json.success) {
                     if (json.minor_check) {
-                        loadMinorCheckForm(attendeeID, $.val('printer_id'), $.val('fee_amount'));
+                        if ($.field('fee_amount')) {
+                            loadMinorCheckForm(attendeeID, $.val('printer_id'), $.val('fee_amount'));
+                        } else {
+                            loadMinorCheckForm(attendeeID, $.val('printer_id'), 0);
+                        }
                     } else {
                         toastr.success(message);
                         loadCheckInFormModal(attendeeID);

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -40,7 +40,9 @@ loadCheckInForm = function () {
     $('#checkin_modal').modal('show');
     $('#checkin_modal .modal-content').load('check_in_form?id={{ attendee.id }}', function () {
         createDateTextEntries();
-        $('#pending_paid_warning').hide();
+        if ($('#pending_paid_warning').length) {
+            $('#pending_paid_warning').hide();
+        }
     });
 }
 var resumeStripeAction = callStripeAction;

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -40,6 +40,7 @@ loadCheckInForm = function () {
     $('#checkin_modal').modal('show');
     $('#checkin_modal .modal-content').load('check_in_form?id={{ attendee.id }}', function () {
         createDateTextEntries();
+        $('#pending_paid_warning').hide();
     });
 }
 var resumeStripeAction = callStripeAction;


### PR DESCRIPTION
Because of how aynchronous calls work, when an admin takes a payment through Stripe, the check-in modal loads too soon to see that the attendee has been marked paid. Now we hide the alert when loading the check-in modal from the payment modal -- if something truly went wrong with the payment, the attendee will still be prevented from checking in, and if that's the case you'll need manager intervention anyway.