### PR TITLE
Switch headers for assign locations page

### DIFF
--- a/uber/templates/art_show_admin/assign_locations.html
+++ b/uber/templates/art_show_admin/assign_locations.html
@@ -12,8 +12,8 @@
     <thead><tr>
         <th>Artist Name</th>
         <th>Real Name</th>
-        <th>Mature Grids</th>
         <th>General Grids</th>
+        <th>Mature Grids</th>
         <th>General Tables</th>
         <th>Mature Tables</th>
         <th>Location</th>


### PR DESCRIPTION
The general/mature grid table headers are backwards on this page! This fixes that.