### PR TITLE
Catch duplicate badge numbers better

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -443,7 +443,7 @@ def dupe_badge_num(attendee):
             and c.NUMBERED_BADGES and attendee.badge_num \
             and (not c.SHIFT_CUSTOM_BADGES or c.AFTER_PRINTED_BADGE_DEADLINE or c.AT_THE_CON):
         with Session() as session:
-            existing = session.query(Attendee).filter_by(badge_type=attendee.badge_type_real, badge_num=attendee.badge_num)
+            existing = session.query(Attendee).filter_by(badge_num=attendee.badge_num)
             if existing.count():
                 return 'That badge number already belongs to {!r}'.format(existing.first().full_name)
 


### PR DESCRIPTION
We were filtering by badge type while checking for numbers, but this means we would hit a DB error an awful lot. Now we just look for the same badge number, not the same badge type.