### PR TITLE
Bypass int casting error

### DIFF
--- a/uber/site_sections/art_show_admin.py
+++ b/uber/site_sections/art_show_admin.py
@@ -778,7 +778,7 @@ class Root:
         charge = Charge(attendee,
                         amount=amount,
                         description='{}ayment for {}\'s art show purchases'.format(
-                            'P' if int(amount) == receipt.total else 'Partial p',
+                            'P' if int(float(amount)) == receipt.total else 'Partial p',
                             attendee.full_name))
         stripe_intent = charge.create_stripe_intent(session)
         message = stripe_intent if isinstance(stripe_intent, string_types) else ''


### PR DESCRIPTION
It's disconcerting that we don't know why this is happening, but this should least stop the error that's preventing card payment.