### PR TITLE
Add optional fields approved dealers can edit

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -311,6 +311,13 @@ transferable_badge_types = string_list(default=list('attendee_badge'))
 # other events with custom fields can add fields.
 untransferable_attrs = string_list(default=list('first_name','last_name','legal_name','email','birthdate','zip_code','international','ec_name','ec_phone','cellphone','interests','age_group','staffing','requested_depts'))
 
+# A list of fields that dealers can edit after they've been approved.
+# Waitlisted dealers can always edit all fields, and declined or canelled dealers
+# cannot edit any fields.
+# To make dealer addresses editable, use 'address'. "Other" text fields will always
+# be editable if their corresponding option is editable, e.g., 'categories_text' and 'categories'
+approved_dealer_editable_fields = string_list(default=list())
+
 # By default, staff/volunteers are only allowed to work shifts in a maximum of
 # three different departments. Historically, we've found that working in too
 # many different departments can spread people too thin and cause burn out,

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -94,7 +94,7 @@
 <div class="group_fields">
   <div class="form-group">
     <label for="name" class="col-sm-3 control-label">{{ "Table" if attendee_or_group.is_dealer else "Group" }} Name</label>
-    {% call macros.read_only_if(read_only, attendee_or_group.name) %}
+    {% call macros.read_only_if(read_only, attendee_or_group.name, check_dealer_editable=(group, 'name')) %}
       <div class="col-sm-6">
         <input type="text" name="name" class="form-control" value="{{ name|default(attendee_or_group.name) }}" maxlength="40" />
       </div>
@@ -197,7 +197,10 @@
 {% set read_only = categories_ro or page_ro %}
 <div class="form-group">
   <label for="categories" class="col-sm-3 control-label">What kinds of things do you sell?</label>
-  {% call macros.read_only_if(read_only, group.categories_labels, post_text=("Other: " if not group.categories_labels else ":") + group.categories_text if group.categories_text) %}
+  {% call macros.read_only_if(read_only, 
+                              group.categories_labels, 
+                              post_text=("Other: " if not group.categories_labels else ":") + group.categories_text if group.categories_text,
+                              check_dealer_editable=(group, 'categories')) %}
     <div class="checkbox col-sm-9">
       {{ macros.checkgroup(group, 'categories') }}
     </div>
@@ -224,7 +227,7 @@
 {% set read_only = wares_ro or page_ro %}
 <div class="form-group">
   <label for="wares" class="col-sm-3 control-label">What do you sell?</label>
-  {% call macros.read_only_if(read_only, group.wares) %}
+  {% call macros.read_only_if(read_only, group.wares, check_dealer_editable=(group, 'wares')) %}
     <div class="col-sm-6">
       <textarea class="form-control" name="wares" rows="4">{{ group.wares }}</textarea>
     </div>
@@ -240,7 +243,7 @@
 {% set read_only = description_ro or page_ro %}
 <div class="form-group">
   <label for="description" class="col-sm-3 control-label">Description</label>
-  {% call macros.read_only_if(read_only, group.description) %}
+  {% call macros.read_only_if(read_only, group.description, check_dealer_editable=(group, 'description')) %}
     <div class="col-sm-6">
       <textarea class="form-control" name="description" rows="4" maxlength="400">{{ group.description }}</textarea>
     </div>
@@ -256,7 +259,7 @@
 {% set read_only = special_needs_ro or page_ro %}
 <div class="form-group">
   <label for="special_needs" class="col-sm-3 control-label optional-field">Table Requests and Special Requests</label>
-  {% call macros.read_only_if(read_only, group.special_needs) %}
+  {% call macros.read_only_if(read_only, group.special_needs, check_dealer_editable=(group, 'special_needs')) %}
     <div class="col-sm-6">
       <textarea class="form-control" name="special_needs" rows="4" placeholder="E.g., specific table, who you would like to sit near, who you would not like to sit near.">{{ group.special_needs }}</textarea>
     </div>
@@ -272,7 +275,7 @@
 {% set read_only = website_ro or page_ro %}
 <div class="form-group">
   <label for="website" class="col-sm-3 control-label">Website URL</label>
-  {% call macros.read_only_if(read_only, group.website) %}
+  {% call macros.read_only_if(read_only, group.website, check_dealer_editable=(group, 'website')) %}
     <div class="col-sm-6">
       <input class="form-control" type="text" name="website" value="{{ group.website }}" size="40" />
     </div>
@@ -304,7 +307,7 @@
   {% endif %}
 {% endif %}
 
-{{ macros.address_form(group, name_prefix='group_', is_readonly=read_only, is_required=required) }}
+{{ macros.address_form(group, name_prefix='group_', is_readonly=read_only, is_required=required, check_dealer_editable=(group, 'address')) }}
 {% endset %}
 
 

--- a/uber/templates/macros.html
+++ b/uber/templates/macros.html
@@ -9,8 +9,11 @@
 {%- endmacro %}
 
 
-{% macro read_only_if(condition, val, pre_text='', post_text='') %}
+{% macro read_only_if(condition, val, pre_text='', post_text='', check_dealer_editable=(None, '')) %}
+{% set group, field_name = check_dealer_editable %}
 {% if not condition %}
+  {{ caller() }}
+{% elif group and group.is_dealer and group.status == c.APPROVED and field_name in c.APPROVED_DEALER_EDITABLE_FIELDS %}
   {{ caller() }}
 {% else %}
   <div class="col-sm-6 form-control-static">
@@ -399,7 +402,9 @@
 {%- endmacro %}
 
 
-{% macro address_form(model, name_prefix='', model_prefix='', label_prefix='', update_international=False, is_required=False, is_readonly=False) -%}
+{% macro address_form(model, name_prefix='', model_prefix='', label_prefix='', update_international=False, is_required=False, is_readonly=False, check_dealer_editable=(None, '')) -%}
+  {%- set group, field_name = check_dealer_editable -%}
+  {%- set is_readonly = False if group.is_dealer and group.status == c.APPROVED and field_name in c.APPROVED_DEALER_EDITABLE_FIELDS else is_readonly -%}
   {%- set suffix = model.id|replace("-", "") -%}
   {%- set zip_code_attr = model_prefix ~ 'zip_code' -%}
   {%- set address1_attr = model_prefix ~ 'address1' -%}
@@ -440,15 +445,7 @@
 
           $('#region{{ suffix }}').val('{{ model[region_attr] }}');
           regionChange{{ suffix }}();
-          {% if model.is_dealer and model.status in [c.APPROVED, c.CANCELLED, c.DECLINED] and not admin_area %}
-            $(function() {
-                if($("select[name='group_region']").is(":visible")) {
-                  $("[name='group_region']").prop("disabled", false);
-                  $("select[name='group_region']").prop("disabled", true);
-                }
-                $("[placeholder='Country']").prop("readonly", true);
-            });
-          {% endif %}
+          
       });
   </script>
   <input type="hidden" class="address_suffixes" value="{{ suffix }}" />

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -68,7 +68,7 @@
       <h2>"{{ group.name }}" Information</h2>
       <form method="post" action="group_members" class="form-horizontal" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />
-        {% if not page_ro %}{{ group_fields.group_name }}{% endif %}
+        {% if not page_ro or 'name' in c.APPROVED_DEALER_EDITABLE_FIELDS and group.status == c.APPROVED %}{{ group_fields.group_name }}{% endif %}
         {{ group_fields.categories }}
         {{ group_fields.wares }}
         {{ group_fields.description }}
@@ -76,7 +76,7 @@
         {{ group_fields.website }}
         {{ group_fields.address }}
         {% include "groupextra.html" %}
-        {% if not page_ro %}
+        {% if not page_ro or c.APPROVED_DEALER_EDITABLE_FIELDS and group.status == c.APPROVED %}
         <button type="submit" class="btn btn-primary" value="Update Application">Update Application</button>
         <button type="submit" class="btn btn-danger" value="Cancel {{ c.DEALER_APP_TERM|title }}" form="cancel_dealer">Cancel Application</button>
         {% endif %}


### PR DESCRIPTION
Adds a new config value "approved_dealer_editable_fields," which lets you set certain group fields that dealers will be able to edit after being approved.