### PR TITLE
Switch to access token for SignNow

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -931,6 +931,8 @@ class SecretConfig(_Overridable):
 
 c = Config()
 _secret = SecretConfig()
+aws_secrets_client = uber.utils.AWSSecretFetcher()
+aws_secrets_client.get_all_secrets()
 
 _config = parse_config(__file__)  # outside this module, we use the above c global instead of using this directly
 

--- a/uber/config.py
+++ b/uber/config.py
@@ -12,6 +12,7 @@ from hashlib import sha512
 from itertools import chain
 
 import cherrypy
+import signnow_python_sdk
 import stripe
 from pockets import keydefaultdict, nesteddefaultdict, unwrap
 from pockets.autolog import log
@@ -894,47 +895,106 @@ class SecretConfig(_Overridable):
         else:
             return _config['secret']['sqlalchemy_url']
 
-    @request_cached_property
-    def SIGNNOW_SDK(self):
-        import signnow_python_sdk
 
-        signnow_python_sdk.Config(client_id=c.SIGNNOW_CLIENT_ID,
-                              client_secret=c.SIGNNOW_CLIENT_SECRET,
-                              environment=c.SIGNNOW_ENV)
+class AWSSecretFetcher:
+    """
+    This class manages fetching secrets from AWS. Some secrets only need to be
+    fetched once, while others may be re-fetched to refresh tokens.
+    """
 
-        return signnow_python_sdk
+    def __init__(self):
+        import boto3
+        
+        aws_session = boto3.session.Session(
+            aws_access_key_id=c.AWS_ACCESS_KEY,
+            aws_secret_access_key=c.AWS_SECRET_KEY
+        )
 
-    # The two static methods below are based on SignNow's Python SDK, which is horribly out of date.
-    @staticmethod
-    def signnow_create_link(access_token, document_id, first_name="", last_name="", redirect_uri=""):
-        from requests import post
-        from json import dumps, loads
-        """Creates shortened signing link urls that can be clicked be opened in a browser to sign the document
-        Args:
-            access_token (str): The access token of an account that has access to the document.
-            document_id (str): The unique id of the document you want to create the links for.
-            redirect_uri (str): The URL to redirect the user when they are done signing the document.
-        Returns:
-            dict: A dictionary representing the JSON response containing the signing links for the document.
-        """
-        response = post(c.SIGNNOW_SDK.Config().get_base_url() + '/link', headers={
-            "Authorization": "Bearer " + access_token,
-            "Content-Type": "application/json",
-            "Accept": "application/json"
-        }, data=dumps({
-            "document_id": document_id,
-            "firstname": first_name,
-            "lastname": last_name,
-            "redirect_uri": redirect_uri
-        }))
-        return loads(response.content)
+        self.client = aws_session.client(
+            service_name=c.AWS_SECRET_SERVICE_NAME,
+            region_name=c.AWS_REGION or 'us-east-2'
+        )
+
+    def get_secret(self, secret_name):
+        import json
+        from botocore.exceptions import ClientError
+
+        try:
+            get_secret_value_response = self.client.get_secret_value(
+                SecretId=secret_name
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'DecryptionFailureException':
+                # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+                log.error("Retrieving secret error: Wrong KMS key ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InternalServiceErrorException':
+                # An error occurred on the server side.
+                log.error("Retrieving secret error: Server error ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InvalidParameterException':
+                # You provided an invalid value for a parameter.
+                log.error("Retrieving secret error: Invalid parameter ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InvalidRequestException':
+                # You provided a parameter value that is not valid for the current state of the resource.
+                log.error("Retrieving secret error: Invalid parameter ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'ResourceNotFoundException':
+                # We can't find the resource that you asked for.
+                log.error("Retrieving secret error: Resource not found ({}).".format(str(e)))
+                return
+        
+        # Decrypts secret using the associated KMS key.
+        if 'SecretString' in get_secret_value_response:
+            secret = json.loads(get_secret_value_response['SecretString'])
+        else:
+            return
+
+        return secret
+
+    def get_all_secrets(self):
+        if c.AWS_AUTH0_SECRET_NAME:
+            self.get_auth0_secret()
+
+        if c.AWS_SIGNNOW_SECRET_NAME:
+            self.get_signnow_secret()
+
+    def get_auth0_secret(self):
+        auth0_secret = self.client.get_secret(c.AWS_AUTH0_SECRET_NAME)
+        if auth0_secret:
+            c.AUTH_DOMAIN = auth0_secret('AUTH0_DOMAIN', '') or c.AUTH_DOMAIN
+            c.AUTH_CLIENT_ID = auth0_secret('CLIENT_ID', '') or c.AUTH_CLIENT_ID
+            c.AUTH_CLIENT_SECRET = auth0_secret('CLIENT_SECRET', '') or c.AUTH_CLIENT_SECRET
+        else:
+            log.error("Error getting Auth0 secret: {}".format(auth0_secret))
+
+    def get_signnow_secret(self):
+        signnow_secret = self.client.get_secret(c.AWS_SIGNNOW_SECRET_NAME)
+        if signnow_secret:
+            c.SIGNNOW_ACCESS_TOKEN = signnow_secret.get('username', '') or c.SIGNNOW_ACCESS_TOKEN
+            c.SIGNNOW_CLIENT_ID = signnow_secret.get('client_id', '') or c.SIGNNOW_CLIENT_ID
+            c.SIGNNOW_CLIENT_SECRET = signnow_secret.get('client_secret', '') or c.SIGNNOW_CLIENT_SECRET
+            c.SIGNNOW_DEALER_TEMPLATE_ID = signnow_secret.get('dealer_template_id') or c.SIGNNOW_DEALER_TEMPLATE_ID
+            c.SIGNNOW_DEALER_FOLDER_ID = signnow_secret.get('dealer_folder_id') or c.SIGNNOW_DEALER_FOLDER_ID
+        else:
+            log.error("Error getting SignNow secret: {}".format(signnow_secret))
+
 
 c = Config()
 _secret = SecretConfig()
-aws_secrets_client = uber.utils.AWSSecretFetcher()
-aws_secrets_client.get_all_secrets()
-
 _config = parse_config(__file__)  # outside this module, we use the above c global instead of using this directly
+
+if c.AWS_SECRET_SERVICE_NAME:
+    aws_secrets_client = AWSSecretFetcher()
+    aws_secrets_client.get_all_secrets()
+else:
+    aws_secrets_client = None
+
+signnow_python_sdk.Config(client_id=c.SIGNNOW_CLIENT_ID,
+                          client_secret=c.SIGNNOW_CLIENT_SECRET,
+                          environment=c.SIGNNOW_ENV)
+signnow_sdk = signnow_python_sdk
 
 
 def _unrepr(d):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -789,6 +789,13 @@ slow_load_check = boolean(default=True)
 # user's web browser.  Put options in this section you would never want being
 # public such as email crendtials and lists of banned attendees.
 
+# Settings for using AWS' secrets fetching feature
+aws_region = string(default="us-east-2")
+aws_secret_service_name = string(default="")
+
+aws_signnow_secret_name = string(default="")
+aws_auth0_secret_name = string(default="")
+
 # Link to a secure document portal for guest groups to upload sensitive documents to.
 secure_document_url = string(default='')
 
@@ -806,9 +813,8 @@ signnow_dealer_folder_id = string(default='') # If set, new documents are moved 
 
 signnow_client_id = string(default='')
 signnow_client_secret = string(default='')
-# Yes, they really need your username and password.
-signnow_username = string(default='')
-signnow_password = string(default='')
+
+signnow_access_token = string(default='')
 
 # Used to connect to our celery task queue broker, for example RabbitMQ
 broker_url = string(default="amqp://localhost//")
@@ -841,7 +847,6 @@ stripe_endpoint_secret = string(default="")
 auth_domain = string(default="")
 auth_client_id = string(default="")
 auth_client_secret = string(default="")
-auth_app_secret = string(default="")
 
 # This list is checked when attendeees preregister and sign up as volunteers.
 # You should enter the full names including all common nicknames as separate

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -221,7 +221,7 @@ url_base = string(default="%(url_root)s%(path)s")
 # Generally this will only need to be changed for localhost systems
 redirect_url_base = string(default="%(url_base)")
 
-# Configuration for AWS email sending
+# Configuration for AWS email sending and secrets fetching feature
 aws_region = string(default="us-east-1")
 
 # Redirect 404s to Uber's default URL
@@ -790,7 +790,6 @@ slow_load_check = boolean(default=True)
 # public such as email crendtials and lists of banned attendees.
 
 # Settings for using AWS' secrets fetching feature
-aws_region = string(default="us-east-2")
 aws_secret_service_name = string(default="")
 
 aws_signnow_secret_name = string(default="")
@@ -815,6 +814,11 @@ signnow_client_id = string(default='')
 signnow_client_secret = string(default='')
 
 signnow_access_token = string(default='')
+
+# Username/password is the officially support auth method for SignNow
+# But that's dumb so these are only used if dev_box is set to true
+signnow_username = string(default='')
+signnow_password = string(default='')
 
 # Used to connect to our celery task queue broker, for example RabbitMQ
 broker_url = string(default="amqp://localhost//")

--- a/uber/models/legal.py
+++ b/uber/models/legal.py
@@ -17,6 +17,7 @@ from uber.models import MagModel
 from uber.models.admin import AdminAccount
 from uber.models.email import Email
 from uber.models.types import Choice, DefaultColumn as Column, MultiChoice
+from uber.utils import SignNowDocument
 
 __all__ = ['SignedDocument']
 
@@ -28,3 +29,17 @@ class SignedDocument(MagModel):
     ident = Column(UnicodeText)
     signed = Column(UTCDateTime, nullable=True, default=None)
     declined = Column(UTCDateTime, nullable=True, default=None)
+
+    def get_dealer_signing_link(self, group):
+        d = SignNowDocument()
+        
+        if not self.document_id:
+            self.document_id = d.create_document(template_id=c.SIGNNOW_DEALER_TEMPLATE_ID,
+                                                 doc_title="Dealer T&C for {}".format(group.name),
+                                                 folder_id=c.SIGNNOW_DEALER_FOLDER_ID)
+        if not self.signed:
+            return d.get_signing_link(self.document_id,
+                                      group.leader.first_name,
+                                      group.leader.last_name,
+                                      c.URL_BASE + '/preregistration/dealer_confirmation?id={}'
+                                      .format(group.id))

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -19,7 +19,7 @@ from uber.errors import HTTPRedirect
 from uber.models import Attendee, AttendeeAccount, Attraction, Email, Group, PromoCode, PromoCodeGroup, SignedDocument, Tracking
 from uber.tasks.email import send_email
 from uber.utils import add_opt, check, check_pii_consent, localized_now, normalize_email, genpasswd, valid_email, \
-    valid_password, Charge
+    valid_password, Charge, SignNowDocument
 
 
 def check_post_con(klass):
@@ -135,43 +135,6 @@ def set_up_new_account(session, attendee, email=None):
         body,
         format='html',
         model=account.to_dict('id'))
-
-def dealer_tc_sign_link(group, document_id=''):
-    from uber.config import aws_secrets_client
-
-    if not document_id:
-        # Create a document from the template
-        document_request = c.SIGNNOW_SDK.Template.copy(c.SIGNNOW_ACCESS_TOKEN,
-                                                       c.SIGNNOW_DEALER_TEMPLATE_ID,
-                                                       "Dealer T&C for {}".format(group.name))
-        if 'error' in document_request:
-            if document_request['error'] == 'invalid_token':
-                aws_secrets_client.get_signnow_secret() # Refreshes the access token
-                document_request = c.SIGNNOW_SDK.Template.copy(c.SIGNNOW_ACCESS_TOKEN,
-                                                               c.SIGNNOW_DEALER_TEMPLATE_ID,
-                                                               "Dealer T&C for {}".format(group.name))
-                if 'error' in document_request:
-                    log.error("Error creating document from template: " + document_request['error'])
-                    return None, None
-
-        document_id = document_request.get('id', '')
-
-        if c.SIGNNOW_DEALER_FOLDER_ID:
-            result = c.SIGNNOW_SDK.Document.move(c.SIGNNOW_ACCESS_TOKEN,
-                                                    document_id,
-                                                    c.SIGNNOW_DEALER_FOLDER_ID)
-            if 'error' in result:
-                log.error("Error moving document into folder: " + result['error'])
-    
-    # Create the signing link for a document.
-    signing_request = c.signnow_create_link(c.SIGNNOW_ACCESS_TOKEN,
-                                            document_id,
-                                            group.leader.first_name,
-                                            group.leader.last_name,
-                                            c.URL_BASE + '/preregistration/dealer_confirmation?id={}'
-                                            .format(group.id))
-
-    return document_id, signing_request.get('url_no_signup')
 
 @all_renderable(public=True)
 @check_post_con
@@ -693,10 +656,14 @@ class Root:
             else:
                 document = existing_doc or SignedDocument(fk_id=group.id, model="Group", ident="terms_and_conditions")
                 session.add(document)
-                document.document_id, redirect_link = dealer_tc_sign_link(group, document.document_id)
+                redirect_link = document.get_dealer_signing_link(group)
                 if redirect_link:
                     raise HTTPRedirect(redirect_link)
             session.commit()
+            if group.status != c.UNAPPROVED:
+                # Dealers always hit this page after signing their terms and conditions
+                # We want new dealers to see the confirmation page, and everyone else to go to their group page
+                raise HTTPRedirect('group_members?id={}&message={}', group.id, "Thank you for signing the terms and conditions!")
         return {'group': group}
 
     @id_required(PromoCodeGroup)
@@ -789,6 +756,22 @@ class Root:
     @log_pageview
     def group_members(self, session, id, message='', **params):
         group = session.group(id)
+
+        if group.is_dealer:
+            signnow_document = session.query(SignedDocument).filter_by(model="Group", fk_id=group.id).first() \
+                                        or SignedDocument(fk_id=group.id,
+                                                            model="Group",
+                                                            ident="terms_and_conditions")
+            signnow_link = ''
+
+            if signnow_document.signed:
+                d = SignNowDocument()
+                signnow_link = d.get_download_link(signnow_document.document_id)
+                if d.error_message:
+                    log.error(d.error_message)
+            else:
+                signnow_link = signnow_document.get_dealer_signing_link(group)
+
         if cherrypy.request.method == 'POST':
             # Both the Attendee class and Group class have identically named
             # address fields. In order to distinguish the two sets of address
@@ -825,6 +808,8 @@ class Root:
             'account': session.one_badge_attendee_account(group.leader),
             'current_account': session.current_attendee_account(),
             'upgraded_badges': len([a for a in group.attendees if a.badge_type in c.BADGE_TYPE_PRICES]),
+            'signnow_document': signnow_document,
+            'signnow_link': signnow_link,
             'message': message
         }
 

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -3,6 +3,31 @@
 
 {%- set attendee_or_group = attendee if attendee else group -%}
 
+{% set signed_document %}
+{% if c.SIGNNOW_DEALER_TEMPLATE_ID and signnow_link %}
+  {% if signnow_document and signnow_document.signed %}
+  <span id="tc-link">
+    <a href="{{ signnow_link }}" class="btn btn-info" target="_blank" role="button">
+      <span class="glyphicon glyphicon-download"></span> Terms and Conditions
+    </a>
+  </span>
+  <script type="text/javascript">
+    $(function() {
+      $('#tc-link').insertAfter($("button[form='cancel_dealer']"));
+    });
+  </script>
+  {% else %}
+  <div class="alert alert-danger">
+    <p>We need you to sign our terms and conditions for vending at {{ c.EVENT_NAME }}.</p>
+    <p><a href="{{ signnow_link }}" class="btn btn-primary" target="_blank">
+      {% if group.signnow_document %}Finish Signing{% else %}Review and Sign{% endif %}
+    </a></p>
+    <p>Make sure to click "DONE" in the top right to confirm your signature.</p>
+  </div>
+  {% endif %}
+{% endif %}
+{% endset %}
+
 
 {% set status %}
 {% set read_only = group_status_ro or page_ro %}
@@ -62,7 +87,7 @@
       <br/><br/>If you would like, you may instead
       <a href="../marketplace/index?attendee_id={{ group.leader.id }}" target="_blank">apply for a table in the Marketplace.</a>{% endif %}
   {% endif %}
-</div>
+  </div>
 {% endif %}
 <script type="text/javascript">
   var unapprove = function(action, convert) {

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -65,6 +65,7 @@
     {% endif %}
     {% if group.is_dealer %}
       {{ group_fields.status }}
+      {{ group_fields.signed_document }}
       <h2>"{{ group.name }}" Information</h2>
       <form method="post" action="group_members" class="form-horizontal" role="form">
         <input type="hidden" name="id" value="{{ group.id }}" />

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1252,6 +1252,87 @@ class Charge:
             return matching_stripe_txns
 
 
+class AWSSecretFetcher:
+    """
+    This class manages fetching secrets from AWS. Some secrets only need to be
+    fetched once, while others may be re-fetched to refresh tokens.
+    """
+
+    def __init__(self):
+        import boto3
+        aws_session = boto3.session.Session(
+            aws_access_key_id=c.AWS_ACCESS_KEY,
+            aws_secret_access_key=c.AWS_SECRET_KEY
+        )
+
+        self.client = aws_session.client(
+            service_name=c.AWS_SECRET_SERVICE_NAME,
+            region_name=c.AWS_REGION
+        )
+
+    def get_secret(self, secret_name):
+        import json
+        from botocore.exceptions import ClientError
+
+        try:
+            get_secret_value_response = self.client.get_secret_value(
+                SecretId=secret_name
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'DecryptionFailureException':
+                # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+                log.error("Retrieving secret error: Wrong KMS key ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InternalServiceErrorException':
+                # An error occurred on the server side.
+                log.error("Retrieving secret error: Server error ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InvalidParameterException':
+                # You provided an invalid value for a parameter.
+                log.error("Retrieving secret error: Invalid parameter ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'InvalidRequestException':
+                # You provided a parameter value that is not valid for the current state of the resource.
+                log.error("Retrieving secret error: Invalid parameter ({}).".format(str(e)))
+                return
+            elif e.response['Error']['Code'] == 'ResourceNotFoundException':
+                # We can't find the resource that you asked for.
+                log.error("Retrieving secret error: Resource not found ({}).".format(str(e)))
+                return
+        
+        # Decrypts secret using the associated KMS key.
+        if 'SecretString' in get_secret_value_response:
+            secret = json.loads(get_secret_value_response['SecretString'])
+        else:
+            return
+
+        return secret
+
+    def get_all_secrets(self):
+        self.get_auth0_secret()
+        self.get_signnow_secret()
+
+    def get_auth0_secret(self):
+        auth0_secret = self.client.get_secret(c.AWS_AUTH0_SECRET_NAME)
+        if auth0_secret:
+            c.AUTH_DOMAIN = auth0_secret('AUTH0_DOMAIN', '') or c.AUTH_DOMAIN
+            c.AUTH_CLIENT_ID = auth0_secret('CLIENT_ID', '') or c.AUTH_CLIENT_ID
+            c.AUTH_CLIENT_SECRET = auth0_secret('CLIENT_SECRET', '') or c.AUTH_CLIENT_SECRET
+        else:
+            log.error("Error getting Auth0 secret: {}".format(auth0_secret))
+
+    def get_signnow_secret(self):
+        signnow_secret = self.client.get_secret(c.AWS_SIGNNOW_SECRET_NAME)
+        if signnow_secret:
+            c.SIGNNOW_ACCESS_TOKEN = signnow_secret.get('username', '') or c.SIGNNOW_ACCESS_TOKEN
+            c.SIGNNOW_CLIENT_ID = signnow_secret.get('client_id', '') or c.SIGNNOW_CLIENT_ID
+            c.SIGNNOW_CLIENT_SECRET = signnow_secret.get('client_secret', '') or c.SIGNNOW_CLIENT_SECRET
+            c.SIGNNOW_DEALER_TEMPLATE_ID = signnow_secret.get('dealer_template_id') or c.SIGNNOW_DEALER_TEMPLATE_ID
+            c.SIGNNOW_DEALER_FOLDER_ID = signnow_secret.get('dealer_folder_id') or c.SIGNNOW_DEALER_FOLDER_ID
+        else:
+            log.error("Error getting SignNow secret: {}".format(signnow_secret))
+
+
 class TaskUtils:
     """
     Utility functions for use in celery tasks.


### PR DESCRIPTION
Also moves the AWS secret fetching into the main plugin for easier integration with page handlers.

I have no idea how to test this on my local system, but I wanted to file the PR before I forgot.