### PR TITLE
Fix dealer prereg form

### DIFF
--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -264,7 +264,7 @@
         // is a dealer or group leader.
         if ($(BADGE_TYPES.row).size()) {
             // Actually, don't show any buttons at all for dealers
-            if ($.field('badge_type').val() != '{{ c.PSEUDO_DEALER_BADGE }}') {
+            if ($.field('badge_type').val() == '{{ c.PSEUDO_DEALER_BADGE }}') {
               $("#badge-types").hide();
             }
             $.each(BADGE_TYPES.options, function (i, badgeType) {

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -8,13 +8,13 @@
 
     {% if not group.is_new %} 
     <h1>
-    <a class="btn btn-primary" href="../preregistration/group_members?id={{ group.id }}">Assign Badges</a>
+    <a class="btn btn-primary" href="../preregistration/group_members?id={{ group.id }}">View as Attendee</a>
     {% if group.guest %} 
     <a class="btn btn-info" href="../guests/index?id={{ group.guest.id }}">{{ group.guest.group_type_label }} Checklist</a>
     {% endif %}
     </h1> 
     {% endif %}
-
+<div class="panel panel-body">
   {% if not group.is_new %}
     <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
@@ -168,6 +168,7 @@
         </div>
         {% endif %}
         </div>
+      </div>
 <script src="../static/js/window-hash-tabload.js" type="text/javascript"></script>
 {% if group.is_new %}
 <script type="text/javascript">


### PR DESCRIPTION
The merge from MAGFest caused the dealer prereg form to misbehave, prompting you to select a badge type when you shouldn't be able to. Also adds a background to the dealer admin form because I was sick of looking at it.