### PR TITLE
Fix redirect URL

### DIFF
--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -219,7 +219,7 @@ url_base = string(default="%(url_root)s%(path)s")
 
 # This is the URL provided to outside services for redirecting back to the app
 # Generally this will only need to be changed for localhost systems
-redirect_url_base = string(default="%(url_base)")
+redirect_url_base = string(default="")
 
 # Configuration for AWS email sending and secrets fetching feature
 aws_region = string(default="us-east-1")

--- a/uber/models/legal.py
+++ b/uber/models/legal.py
@@ -41,5 +41,5 @@ class SignedDocument(MagModel):
             return d.get_signing_link(self.document_id,
                                       group.leader.first_name,
                                       group.leader.last_name,
-                                      c.URL_BASE + '/preregistration/dealer_confirmation?id={}'
+                                      (c.REDIRECT_URL_BASE or c.URL_BASE) + '/preregistration/dealer_confirmation?id={}'
                                       .format(group.id))

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -917,7 +917,7 @@ class ExcelWorksheetStreamWriter:
 class OAuthRequest:
 
     def __init__(self, scope='openid profile email', state=None):
-        self.redirect_uri = c.REDIRECT_URL_BASE + "/rams/accounts/"
+        self.redirect_uri = (c.REDIRECT_URL_BASE or c.URL_BASE) + "/rams/accounts/"
         self.client = OAuth2Session(c.AUTH_CLIENT_ID, c.AUTH_CLIENT_SECRET, scope=scope, state=state, redirect_uri=self.redirect_uri + "process_login")
         self.state = state if state else None
 


### PR DESCRIPTION
We were redirecting people to the literal string "%(url_base)". Now we just use the redirect URL only if it's actually set. Also actually uses the redirect URL for the signnow integration.