### PR TITLE
Avoid giving dealers expired signing links

### DIFF
--- a/uber/models/legal.py
+++ b/uber/models/legal.py
@@ -30,6 +30,17 @@ class SignedDocument(MagModel):
     signed = Column(UTCDateTime, nullable=True, default=None)
     declined = Column(UTCDateTime, nullable=True, default=None)
 
+    def get_doc_signed_timestamp(self, document_id=""):
+        d = SignNowDocument()
+        document_id = document_id or self.document_id
+
+        if not document_id:
+            return
+        
+        document = d.get_document_details(document_id)
+        if document.get('signatures'):
+            return document['signatures'][0].get('created')
+
     def get_dealer_signing_link(self, group):
         d = SignNowDocument()
         

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -823,7 +823,16 @@ class Root:
                 if d.error_message:
                     log.error(d.error_message)
             else:
-                signnow_link = signnow_document.get_dealer_signing_link(group)
+                signed = signnow_document.get_doc_signed_timestamp()
+                if signed:
+                    signnow_document.signed = signed
+                    session.add(signnow_document)
+                    d = SignNowDocument()
+                    signnow_link = d.get_download_link(signnow_document.document_id)
+                    if d.error_message:
+                        log.error(d.error_message)
+                else:
+                    signnow_link = signnow_document.get_dealer_signing_link(group)
 
         if cherrypy.request.method == 'POST':
             # Both the Attendee class and Group class have identically named

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1332,6 +1332,15 @@ class SignNowDocument:
             self.error_message = "Error getting download link: " + download_request['error']
         else:
             return download_request.get('link')
+    
+    def get_document_details(self, document_id):
+        self.set_access_token(refresh=True)
+        document_request = signnow_sdk.Document.get(self.access_token, document_id)
+
+        if 'error' in document_request:
+            self.error_message = "Error getting document: " + document_request['error']
+        else:
+            return document_request
 
 
 class TaskUtils:


### PR DESCRIPTION
If a dealer completed signing the T&C but our app never got the redirect callback, we would ask them to sign the T&C but give them a broken link. Now we fetch the document from SignNow and check that it isn't already signed before we ask them to sign it.