### PR TITLE
Finalize SignNow dealer T&C document

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -972,11 +972,9 @@ class AWSSecretFetcher:
     def get_signnow_secret(self):
         signnow_secret = self.get_secret(c.AWS_SIGNNOW_SECRET_NAME)
         if signnow_secret:
-            c.SIGNNOW_ACCESS_TOKEN = signnow_secret.get('username', '') or c.SIGNNOW_ACCESS_TOKEN
-            c.SIGNNOW_CLIENT_ID = signnow_secret.get('client_id', '') or c.SIGNNOW_CLIENT_ID
-            c.SIGNNOW_CLIENT_SECRET = signnow_secret.get('client_secret', '') or c.SIGNNOW_CLIENT_SECRET
-            c.SIGNNOW_DEALER_TEMPLATE_ID = signnow_secret.get('dealer_template_id') or c.SIGNNOW_DEALER_TEMPLATE_ID
-            c.SIGNNOW_DEALER_FOLDER_ID = signnow_secret.get('dealer_folder_id') or c.SIGNNOW_DEALER_FOLDER_ID
+            c.SIGNNOW_ACCESS_TOKEN = signnow_secret.get('ACCESS_TOKEN', '') or c.SIGNNOW_ACCESS_TOKEN
+            c.SIGNNOW_CLIENT_ID = signnow_secret.get('CLIENT_ID', '') or c.SIGNNOW_CLIENT_ID
+            c.SIGNNOW_CLIENT_SECRET = signnow_secret.get('CLIENT_SECRET', '') or c.SIGNNOW_CLIENT_SECRET
 
 
 c = Config()

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -118,6 +118,45 @@ class Group(MagModel, TakesPaymentMixin):
     def assign_creator(self):
         if self.is_new and not self.creator_id:
             self.creator_id = self.session.admin_attendee().id if self.session.admin_attendee() else None
+    
+    @property
+    def signnow_texts_list(self):
+        """
+        Returns a list of JSON representing uneditable texts fields to use for this group's document in SignNow. 
+        """
+        page_number = 2
+        textFont = 'Arial'
+        textLineHeight = 12
+        textSize = 10
+
+        texts_config = [(self.name, 73, 392), (self.email, 73, 436), (self.id, 200, 748)]
+
+        texts = []
+
+        for field, x, y in texts_config:
+            texts.append({
+                "page_number": page_number,
+                "data":        field,
+                "x":           x,
+                "y":           y,
+                "font":        textFont,
+                "line_height": textLineHeight,
+                "size":        6 if field == self.id else textSize,
+            })
+
+        return texts
+
+    @property
+    def signnow_document_signed(self):
+        from uber.models import Session, SignedDocument
+
+        signed = False
+        with Session() as session:
+            document = session.query(SignedDocument).filter_by(model="Group", fk_id=self.id).first()
+            if document and document.signed:
+                signed = True
+
+        return signed
 
     @property
     def sorted_attendees(self):


### PR DESCRIPTION
Includes all the final stuff we need for the terms and conditions, like prefilling in certain fields. Also fixes a bug if a dealer happened to not have a T&C document created at all when they applied.