### PR TITLE
Final fixes for importing dealers

### DIFF
--- a/uber/api.py
+++ b/uber/api.py
@@ -449,6 +449,7 @@ class AttendeeLookup:
         'ec_phone',
         'cellphone',
         'badge_printed_name',
+        'badge_num',
         'found_how',
         'comments',
         'admin_notes',

--- a/uber/automated_emails.py
+++ b/uber/automated_emails.py
@@ -157,7 +157,8 @@ AutomatedEmailFixture(
     AttendeeAccount,
     '{EVENT_NAME} account creation confirmed',
     'reg_workflow/account_confirmation.html',
-    lambda a: not a.password_reset,
+    lambda a: not a.password_reset and (
+              a.created.when_local > c.PREREG_OPEN or a.has_dealer and a.created.when_local > c.DEALER_REG_START),
     needs_approval=False,
     allow_at_the_con=True,
     ident='attendee_account_confirmed')

--- a/uber/badge_funcs.py
+++ b/uber/badge_funcs.py
@@ -126,6 +126,6 @@ def needs_badge_num(attendee=None, badge_type=None):
     if c.NUMBERED_BADGES:
         if attendee:
             return (badge_type in c.PREASSIGNED_BADGE_TYPES or attendee.checked_in) \
-                   and attendee.paid != c.NOT_PAID and attendee.badge_status != c.INVALID_STATUS
+                   and attendee.paid != c.NOT_PAID and attendee.is_valid
         else:
             return badge_type in c.PREASSIGNED_BADGE_TYPES

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1978,6 +1978,10 @@ class AttendeeAccount(MagModel):
         return len(self.attendees) == 1
 
     @property
+    def has_dealer(self):
+        return any([a.is_dealer for a in self.valid_attendees + self.imported_attendees])
+
+    @property
     def valid_attendees(self):
         return [attendee for attendee in self.attendees if attendee.is_valid]
 

--- a/uber/sep_commands.py
+++ b/uber/sep_commands.py
@@ -214,6 +214,7 @@ def send_automated_emails():
     if results:
         print('Unapproved email counts:\n{}'.format(dumps(results, indent=2, sort_keys=True)))
 
+
 @entry_point
 def check_stripe_payments():
     from uber.tasks.registration import check_missed_stripe_payments
@@ -221,6 +222,7 @@ def check_stripe_payments():
     results = timed(check_missed_stripe_payments)()
     if results:
         print('Marked the following payment intents as paid: {}'.format(", ".join(results)))
+
 
 @entry_point
 def process_api_queue():

--- a/uber/templates/base.html
+++ b/uber/templates/base.html
@@ -347,7 +347,7 @@
             }
             // prevent people from paying after prereg closes
             {% if c.PRE_CON %}
-                if ($('form.stripe').size()) {
+                if ($('#stripeModal').size()) {
                     var prevHour = new Date().getHours();
                     var checkHour = function() {
                         var currHour = new Date().getHours();

--- a/uber/templates/emails/reg_workflow/account_confirmation.html
+++ b/uber/templates/emails/reg_workflow/account_confirmation.html
@@ -3,7 +3,7 @@
 <body>
 
     You have created an account for {{ c.EVENT_NAME }} with the following registrations:
-    <ul>{% for attendee in account.attendees %}
+    <ul>{% for attendee in account.valid_attendees %}
         <li>{{ attendee.full_name }} ({{ attendee.badge_type_label }}): {{ attendee.email|email_to_link }}</li>
         {% endfor %}
     </ul>

--- a/uber/templates/group_admin/dealers.html
+++ b/uber/templates/group_admin/dealers.html
@@ -11,13 +11,13 @@
 <div class="panel panel-default">
   <div class="panel-body">
     {{ dealer_groups }} {{ c.DEALER_TERM }} groups ({{ dealer_badges }} badges, {{ tables }} tables)
-    <span class="pull-right"><a href="index?show_all=true#dealers" class="btn btn-info">Show Declined Dealers</a></span>
+    <span class="pull-right"><a href="index?show_all=true#dealers" class="btn btn-info">Show Declined and Imported Dealers</a></span>
     <br/> <br/>
     {{ approved_tables }} approved tables / {{ waitlisted_tables }} waitlisted tables / {{ unapproved_tables }} unapproved tables
   </div>  
 </div>
 
-<div class="table-responsive">
+<div class="table-responsive panel panel-default">
 <table class="table table-striped datatable" data-info="false">
   <thead>
     <tr>
@@ -29,11 +29,12 @@
       <th>Owed</th>
       <th>Paid</th>
       <th>Admin Notes</th>
+      {% if c.SIGNNOW_DEALER_TEMPLATE_ID %}<th>Signed?</th>{% endif %}
     </tr>
   </thead>
   <tbody>
-{% for group in groups if group.is_dealer and (show_all or group.status != c.DECLINED) %}
-    <tr>
+{% for group in groups if group.is_dealer and (show_all or (group.status != c.DECLINED and group.status != c.IMPORTED)) %}
+    <tr{% if c.SIGNNOW_DEALER_TEMPLATE_ID and not group.signnow_document_signed or group.status in [c.DECLINED_STATUS, c.CANCELLED_STATUS] %} class="danger"{% endif %}>
         <td style="text-align:left" data-order="{{ group.name }}" data-search="{{ group.name }}"> <a href="form?id={{ group.id }}">{{ group.name|default('?????', boolean=True) }}</a> </td>
         <td>
             {% if group.is_dealer %}
@@ -48,6 +49,7 @@
         <td>{{ group.amount_unpaid|format_currency }}</td>
         <td>{{ (group.amount_paid / 100)|format_currency }}</td>
         <td>{{ group.admin_notes }}</td>
+        {% if c.SIGNNOW_DEALER_TEMPLATE_ID %}<td>{{ group.signnow_document_signed }}</td>{% endif %}
     </tr>
 {% endfor %}
   </tbody>

--- a/uber/templates/group_admin/guests.html
+++ b/uber/templates/group_admin/guests.html
@@ -1,5 +1,5 @@
 {% set checklist_items = band_checklist_items if band else guest_checklist_items %}
-  <div class="table-responsive">
+  <div class="table-responsive panel panel-default">
     <table class="datatable table table-striped" data-info="false">
       <thead>
       <tr>

--- a/uber/templates/group_admin/index.html
+++ b/uber/templates/group_admin/index.html
@@ -50,6 +50,7 @@
   <div class="tab-content">
   <div class="row" style="padding: 10px;"></div>
   <div role="tabpanel" class="tab-pane" id="all">
+    <div class="panel panel-body">
     <table class="datatable table table-striped">
       <thead>
       <tr>
@@ -79,6 +80,7 @@
       {% endfor -%}
       </tbody>
     </table>
+    </div>
   
   </div>
   {% if c.HAS_GUEST_ADMIN_ACCESS %}

--- a/uber/templates/group_admin/mivs.html
+++ b/uber/templates/group_admin/mivs.html
@@ -1,4 +1,4 @@
-  <div class="table-responsive">
+  <div class="table-responsive panel panel-default">
     <table class="datatable table table-striped" data-info="false">
       <thead>
       <tr>


### PR DESCRIPTION
A handful of miscellaneous fixes for importing:
- Prevent 'account confirmed' emails from sending to imported accounts
- Stop imported badges from being assigned badge numbers
- List only valid attendees in account confirmation emails
- Add panel backing to group list view
- Hide imported dealers from dealer list by default