### PR TITLE
Close the session in get_badge_count_by_type

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -210,11 +210,13 @@ class Config(_Overridable):
         badges, since those have by definition not been promised to anyone.
         """
         from uber.models import Session, Attendee
+        count = 0
         with Session() as session:
-            return session.query(Attendee).filter(
+            count = session.query(Attendee).filter(
                 Attendee.paid != c.NOT_PAID,
                 Attendee.badge_type == badge_type,
                 Attendee.badge_status.in_([c.COMPLETED_STATUS, c.NEW_STATUS])).count()
+        return count
 
     def get_printed_badge_deadline_by_type(self, badge_type):
         """


### PR DESCRIPTION
get_badge_count_by_type returns a value while inside a new SQLAlchemy session, which causes problems with DB connection pool usage. This should fix that.

I have not tested whether this fixes the db connection pool issues, but I'm filing the PR now in case we need it in an emergency.