### PR TITLE
Fix group badge cost

### DIFF
--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1111,11 +1111,11 @@ class Charge:
                     receipt_items.append(ReceiptItem(receipt_id=receipt.id,
                                                      desc=desc,
                                                      amount=cost,
-                                                     count=count,
+                                                     count=cost[price],
                                                      who=AdminAccount.admin_name() or 'non-admin'
                                                     ))
                 else:
-                    receipt_items.append((desc, price, count))
+                    receipt_items.append((desc, price, cost[price]))
             return receipt_items
         if receipt:
             return [ReceiptItem(receipt_id=receipt.id,


### PR DESCRIPTION
We weren't properly processing groups' badge prices and were always only adding the cost of a single badge.