### PR TITLE
Set API queue processing to once every half-hour

### DIFF
--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -166,7 +166,7 @@ def check_missed_stripe_payments():
     return paid_ids
 
 
-@celery.schedule(timedelta(minutes=10))
+@celery.schedule(timedelta(minutes=30))
 def process_api_queue():
     known_job_names = ['attendee_account_import', 'attendee_import', 'group_import']
     completed_jobs = {}


### PR DESCRIPTION
Importing 1000 attendee accounts takes about 20 minutes, so we're bumping up the interval of API queue processing to avoid clashes.