### PR TITLE
Avoid crashing the template for invalid phone numbers

### DIFF
--- a/uber/custom_tags.py
+++ b/uber/custom_tags.py
@@ -197,9 +197,12 @@ def format_phone(val, country='US'):
     if not val:
         return
         
-    return phonenumbers.format_number(
-        phonenumbers.parse(val, country),
-        PhoneNumberFormat.NATIONAL)
+    try:
+        return phonenumbers.format_number(
+                            phonenumbers.parse(val, country),
+                            PhoneNumberFormat.NATIONAL)
+    except Exception:
+        return val
 
 
 @JinjaEnv.jinja_filter


### PR DESCRIPTION
We're not sure how, but someone ended up with an invalid number on their registration and now they can't see their homepage because phonenumbers throws an Exception. We now effectively bypass that exception, since this is purely for display purposes.