### PR TITLE
Don't call all child badges free

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -751,7 +751,8 @@ class Attendee(MagModel, TakesPaymentMixin):
             return "Could not undo extras, this attendee has an open receipt!"
         self.amount_extra = 0
         self.extra_donation = 0
-        self.badge_type = c.ATTENDEE_BADGE
+        if self.badge_type in c.BADGE_TYPE_PRICES:
+            self.badge_type = c.ATTENDEE_BADGE
 
     def qualifies_for_discounts(self):
         return self.paid != c.NEED_NOT_PAY and self.overridden_price is None and not self.is_dealer

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -60,7 +60,7 @@
               {% if attendee.requested_hotel_info %}
                 <li>Requested hotel booking info</li>
               {% endif %}
-              {% if not attendee.badge_cost and attendee.age_discount and not attendee.promo_code_id %}
+              {% if not attendee.default_badge_cost and attendee.age_discount and not attendee.promo_code_id %}
                 <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
               {% elif attendee.age_discount and attendee.age_group_conf.discount != 0 %}
                 <li>{{ attendee.age_group_conf.discount|format_currency }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>


### PR DESCRIPTION
While fixing child badge registration I noticed that the system was calling any discounted badge free. This fixes that. Also includes a fix for undo_extra for non-MFF events.