### PR TITLE
Better standardize dollars vs cents values

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -411,9 +411,12 @@ class MagModel:
         try:
             cost_calc = receipt_items[self.__class__.__name__][name[8:]](self)
             try:
-                return sum(item[0] * item[1] for item in cost_calc.items()) / 100
+                return sum(item[0] * item[1] for item in cost_calc[1].items()) / 100
             except AttributeError:
-                return cost_calc[1] * cost_calc[2] / 100
+                if len(cost_calc) > 2:
+                    return cost_calc[1] * cost_calc[2] / 100
+                else:
+                    return cost_calc[1] / 100
         except Exception:
             pass
 

--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -133,7 +133,7 @@ class ArtShowApplication(MagModel):
             return 0
         else:
             if self.active_receipt:
-                return self.active_receipt['current_amount_owed']
+                return self.active_receipt['current_amount_owed'] / 100
             return self.potential_cost
 
     @property

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -810,8 +810,8 @@ class Attendee(MagModel, TakesPaymentMixin):
     @property
     def total_cost(self):
         if self.active_receipt:
-            return self.active_receipt['current_amount_owed']
-        return self.default_cost + (self.amount_extra or 0)
+            return self.active_receipt['current_amount_owed'] / 100
+        return self.default_cost
 
     @property
     def total_donation(self):

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -270,14 +270,14 @@ class Group(MagModel, TakesPaymentMixin):
     @property
     def amount_extra(self):
         if self.is_new:
-            return sum(a.total_cost - a.badge_cost for a in self.attendees if a.paid == c.PAID_BY_GROUP)
+            return sum(a.total_cost - a.badge_cost for a in self.attendees if a.paid == c.PAID_BY_GROUP) / 100
         else:
             return 0
 
     @property
     def total_cost(self):
         if self.active_receipt:
-            return self.active_receipt['current_amount_owed']
+            return self.active_receipt['current_amount_owed'] / 100
         return self.default_cost + self.amount_extra
 
     @property

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -11,8 +11,6 @@ from uber.decorators import cost_calculation, credit_calculation
 from uber.models import Attendee
 
 
-
-
 @cost_calculation.MarketplaceApplication
 def app_cost(app):
     if app.status == c.APPROVED:

--- a/uber/templates/art_show_applications/edit.html
+++ b/uber/templates/art_show_applications/edit.html
@@ -12,7 +12,7 @@
   <div class="panel-heading">
     Art Show Application Information
   </div>
-  <div class="panel-body"> {{ app.default_table_cost }}
+  <div class="panel-body">
     {% if (c.ATTRACTIONS_ENABLED and attractions) or attendee.promo_code_groups or attendee.badge_status != c.NOT_ATTENDING or attendee.marketplace_applications %}
       {% include 'confirm_tabs.html' with context %}
     {% endif %}

--- a/uber/templates/emails/dealers/approved.html
+++ b/uber/templates/emails/dealers/approved.html
@@ -17,8 +17,8 @@ Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your applic
 
 This registration includes:
 <ul>
-    <li> {{ group.tables }} table{{ group.tables|pluralize }} ({{ group.table_cost|format_currency }}) </li>
-    <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.badge_cost|format_currency }}) </li>
+    <li> {{ group.tables }} table{{ group.tables|pluralize }} ({{ group.default_table_cost|format_currency }}) </li>
+    <li> {{ group.badges }} badge{{ group.badges|pluralize }} ({{ group.default_badge_cost|format_currency }}) </li>
 </ul>
 
 <br/> <u>{{ c.DEALER_LOC_TERM|title }} Rules and Information</u>


### PR DESCRIPTION
Fixes a bug where sometimes an attendee or art show application's cost would be displayed as cents rather than in dollars. We're keeping most costs/fees as dollars for now since in some cases admins are able to edit these directly and I don't feel like doing a ton of input conversions.

Also fixes issues with dealer's default costs not being calculated correctly.