### PR TITLE
Fix "attendees who are X get in free!" message

### DIFF
--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -75,8 +75,13 @@ def kickin_cost(attendee):
 
 @credit_calculation.Attendee
 def age_discount(attendee):
-    if attendee.qualifies_for_discounts:
-        return ("Age Discount", attendee.age_discount * 100) if attendee.age_discount else None
+    if attendee.qualifies_for_discounts and attendee.age_discount:
+        if abs(attendee.age_discount) > attendee.calculate_badge_cost():
+            age_discount = attendee.calculate_badge_cost() * 100 * -1
+        else:
+            age_discount = attendee.age_discount * 100
+
+        return ("Age Discount", age_discount)
 
 @credit_calculation.Attendee
 def group_discount(attendee):

--- a/uber/templates/preregistration/index.html
+++ b/uber/templates/preregistration/index.html
@@ -60,7 +60,7 @@
               {% if attendee.requested_hotel_info %}
                 <li>Requested hotel booking info</li>
               {% endif %}
-              {% if not attendee.default_badge_cost and attendee.age_discount and not attendee.promo_code_id %}
+              {% if attendee.age_discount and attendee.age_discount|abs > attendee.default_badge_cost and not attendee.promo_code_id %}
                 <li>Attendees who are {{ attendee.age_group_conf.desc|lower }} get in for free!</li>
               {% elif attendee.age_discount and attendee.age_group_conf.discount != 0 %}
                 <li>{{ attendee.age_group_conf.discount|format_currency }} discount for attendees who are {{ attendee.age_group_conf.desc|lower }}.</li>


### PR DESCRIPTION
The default_badge_cost property doesn't actually take age discounts into account, which is by design, so now we have to check the age discount inside the template.