### PR TITLE
Fix a 5-year-old bug in the schedule page

### DIFF
--- a/uber/templates/schedule/edit.html
+++ b/uber/templates/schedule/edit.html
@@ -25,7 +25,7 @@
 </style>
 
 <script type="text/javascript">
-    var SLOT_COUNT = {{ c.PANEL_SCHEDULE_LENGTH }} * 2;
+    var SLOT_COUNT = {{ c.PANEL_SCHEDULE_LENGTH }};
     var EVENTS = {{ events|jsonize }};
     var EPOCH = moment('{{ c.PANELS_EPOCH|datetime_local("%Y-%m-%d %H:%M:%S") }}', 'YYYY-MM-DD HH:mm:ss');
 


### PR DESCRIPTION
The schedule page has been showing twice as many slots as it should since at least 2017. How did we miss this??