### PR TITLE
Fix automated emails double-sending

### DIFF
--- a/alembic/versions/fa2deb095760_add_column_to_track_email_sending.py
+++ b/alembic/versions/fa2deb095760_add_column_to_track_email_sending.py
@@ -1,0 +1,59 @@
+"""Add column to track email sending
+
+Revision ID: fa2deb095760
+Revises: c7a439f29c1c
+Create Date: 2022-11-28 21:45:45.496955
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'fa2deb095760'
+down_revision = 'c7a439f29c1c'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('automated_email', sa.Column('currently_sending', sa.Boolean(), server_default='False', nullable=False))
+
+
+def downgrade():
+    op.drop_column('automated_email', 'currently_sending')

--- a/uber/models/email.py
+++ b/uber/models/email.py
@@ -70,6 +70,7 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
     approved = Column(Boolean, default=False)
     needs_approval = Column(Boolean, default=True)
     unapproved_count = Column(Integer, default=0)
+    currently_sending = Column(Boolean, default=False)
 
     allow_at_the_con = Column(Boolean, default=False)
     allow_post_con = Column(Boolean, default=False)
@@ -104,7 +105,8 @@ class AutomatedEmail(MagModel, BaseEmailMixin):
         now = utils.localized_now()
         return cls.filters_for_allowed + [
             or_(cls.active_after == None, cls.active_after <= now),
-            or_(cls.active_before == None, cls.active_before >= now)]  # noqa: E711
+            or_(cls.active_before == None, cls.active_before >= now),
+            cls.currently_sending == False]  # noqa: E711
 
     @classproperty
     def filters_for_approvable(cls):

--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -139,8 +139,7 @@ def notify_admins_of_pending_emails():
 
         return groupify(pending_emails, 'sender', 'ident')
 
-
-@celery.schedule(timedelta(minutes=5))
+@celery.schedule(timedelta(minutes=5 if c.DEV_BOX else 15))
 def send_automated_emails():
     """
     Send any automated emails that are currently active, and have been approved

--- a/uber/tasks/email.py
+++ b/uber/tasks/email.py
@@ -156,7 +156,11 @@ def send_automated_emails():
             .options(joinedload(AutomatedEmail.emails)).all()
 
         for automated_email in active_automated_emails:
+            automated_email.currently_sending = True
+            session.add(automated_email)
+            session.commit()
             automated_email.unapproved_count = 0
+
         automated_emails_by_model = groupify(active_automated_emails, 'model')
 
         for model, query_func in AutomatedEmailFixture.queries.items():
@@ -170,6 +174,11 @@ def send_automated_emails():
                                 automated_email.send_to(model_instance, delay=False)
                             else:
                                 automated_email.unapproved_count += 1
+        
+        for automated_email in active_automated_emails:
+            automated_email.currently_sending = False
+            session.add(automated_email)
+            session.commit()
 
         return {e.ident: e.unapproved_count for e in active_automated_emails if e.unapproved_count > 0}
 


### PR DESCRIPTION
Email sending is now done every 15 minutes instead of ever 5 minutes, unless you're on a development box. The email sending task now also locks all the active email categories while it processes them.