### PR TITLE
Add features and bug fixes required at-event

### DIFF
--- a/uber/models/art_show.py
+++ b/uber/models/art_show.py
@@ -143,6 +143,26 @@ class ArtShowApplication(MagModel):
         else:
             return self.default_cost or 0
 
+    def calc_app_price_change(self, **kwargs):
+        preview_app = ArtShowApplication(**self.to_dict())
+        current_cost = int(self.potential_cost * 100)
+
+        if 'overridden_price' in kwargs:
+            try:
+                preview_app.overridden_price = int(kwargs['overridden_price'])
+            except TypeError:
+                preview_app.overridden_price = kwargs['overridden_price']
+        if 'panels' in kwargs:
+            preview_app.panels = int(kwargs['panels'])
+        if 'panels_ad' in kwargs:
+            preview_app.panels_ad = int(kwargs['panels_ad'])
+        if 'tables' in kwargs:
+            preview_app.tables = int(kwargs['tables'])
+        if 'tables_ad' in kwargs:
+            preview_app.tables_ad = int(kwargs['tables_ad'])
+
+        return current_cost, int(preview_app.potential_cost * 100) - current_cost
+
     @property
     def email(self):
         return self.attendee.email

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -5,7 +5,7 @@ from datetime import date, datetime, timedelta
 from uuid import uuid4
 
 from sqlalchemy.sql.elements import not_
-
+from dateutil import parser as dateparser
 from pockets import cached_property, classproperty, groupify, listify, is_listy, readable_join
 from pockets.autolog import log
 from pytz import UTC
@@ -752,6 +752,10 @@ class Attendee(MagModel, TakesPaymentMixin):
             return cost
 
     def calculate_badge_prices_cost(self, current_badge_type=c.ATTENDEE_BADGE):
+        # This is a special calculation that accounts for badge upgrades for comped attendees
+        # All other badge type changes (i.e. those not to/from a badge type in BADGE_TYPE_PRICES)
+        # use the attendee's actual current badge cost
+
         base_badge_cost = self.new_badge_cost if self.paid == c.NEED_NOT_PAY else self.calculate_badge_cost()
 
         if self.badge_type in c.BADGE_TYPE_PRICES and current_badge_type in c.BADGE_TYPE_PRICES:
@@ -905,6 +909,7 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     def calc_badge_cost_change(self, **kwargs):
         preview_attendee = Attendee(**self.to_dict())
+        new_cost = None
         if 'overridden_price' in kwargs:
             preview_attendee.overridden_price = int(kwargs['overridden_price'])
         if 'badge_type' in kwargs:
@@ -923,10 +928,31 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     def calc_age_discount_change(self, birthdate):
         preview_attendee = Attendee(**self.to_dict())
-        preview_attendee.birthdate = birthdate
-        current_discount = self.age_discount() * 100
+        preview_attendee.birthdate = dateparser.parse(birthdate)
+        current_discount = max(self.badge_cost * 100 * -1, self.age_discount * 100)
+        new_discount = max(self.badge_cost * 100 * -1, preview_attendee.age_discount * 100)
 
-        return current_discount, (preview_attendee.age_discount() * 100) - current_discount
+        if not new_discount:
+            return current_discount, current_discount * -1
+        elif not current_discount:
+            return current_discount, new_discount
+        else:
+            return current_discount, new_discount - current_discount
+
+    def calc_badge_comp_change(self, paid):
+        preview_attendee = Attendee(**self.to_dict())
+        paid = int(paid)
+        comped_or_refunded = [c.NEED_NOT_PAY, c.REFUNDED]
+        preview_attendee.paid = paid
+        if paid != c.NEED_NOT_PAY and self.paid != c.NEED_NOT_PAY:
+            return 0, 0
+        elif self.paid in comped_or_refunded and paid in comped_or_refunded:
+            return 0, 0
+        elif paid == c.NEED_NOT_PAY:
+            return 0, self.badge_cost * -1 * 100
+        else:
+            badge_cost = preview_attendee.calculate_badge_cost() * 100
+            return badge_cost * -1, badge_cost 
 
     @hybrid_property
     def is_unassigned(self):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -825,6 +825,9 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def total_cost(self):
+        if not self.is_valid:
+            return 0
+
         if self.active_receipt:
             return self.active_receipt['item_total'] / 100
         return self.default_cost

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -911,7 +911,10 @@ class Attendee(MagModel, TakesPaymentMixin):
         preview_attendee = Attendee(**self.to_dict())
         new_cost = None
         if 'overridden_price' in kwargs:
-            preview_attendee.overridden_price = int(kwargs['overridden_price'])
+            try:
+                preview_attendee.overridden_price = int(kwargs['overridden_price'])
+            except TypeError:
+                preview_attendee.overridden_price = kwargs['overridden_price']
         if 'badge_type' in kwargs:
             preview_attendee.badge_type = int(kwargs['badge_type'])
             new_cost = preview_attendee.calculate_badge_prices_cost(self.badge_type) * 100

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -276,6 +276,9 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def total_cost(self):
+        if not self.is_valid:
+            return 0
+
         if self.active_receipt:
             return self.active_receipt['item_total'] / 100
         return self.default_cost + self.amount_extra

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -114,6 +114,28 @@ class Group(MagModel, TakesPaymentMixin):
                 purchased_items[cost_label] = cost * badges_by_cost[cost]
         
         return purchased_items
+
+    def calc_group_price_change(self, **kwargs):
+        preview_group = Group(**self.to_dict())
+        current_cost = int(self.cost * 100)
+        new_cost = None
+
+        if 'cost' in kwargs:
+            try:
+                preview_group.cost = int(kwargs['cost'])
+            except TypeError:
+                preview_group.cost = 0
+            new_cost = preview_group.cost * 100
+        if 'tables' in kwargs:
+            preview_group.tables = int(kwargs['tables'])
+            return self.default_table_cost * 100, (preview_group.default_table_cost * 100) - (self.default_table_cost * 100)
+        if 'badges' in kwargs:
+            num_new_badges = int(kwargs['badges']) - self.badges_purchased
+            return self.current_badge_cost * 100, self.new_badge_cost * num_new_badges * 100
+
+        if not new_cost:
+            new_cost = int(preview_group.default_cost * 100)
+        return current_cost, new_cost - current_cost
                 
     @presave_adjustment
     def assign_creator(self):
@@ -262,6 +284,20 @@ class Group(MagModel, TakesPaymentMixin):
     def unregistered_badges(cls):
         from uber.models import Attendee
         return exists().where(and_(Attendee.group_id == cls.id, Attendee.first_name == ''))
+
+    @property
+    def current_badge_cost(self):
+        total_badge_cost = 0
+
+        if not self.auto_recalc:
+            return 0
+        
+        for attendee in self.attendees:
+            if attendee.paid == c.PAID_BY_GROUP and attendee.badge_cost:
+                total_badge_cost += attendee.badge_cost
+
+        return total_badge_cost
+
 
     @property
     def new_badge_cost(self):

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -381,6 +381,8 @@ class Group(MagModel, TakesPaymentMixin):
 
     @property
     def min_badges_addable(self):
+        if not c.PRE_CON:
+            return 0
         if self.is_dealer and not self.dealer_badges_remaining or self.amount_unpaid:
             return 0
         if self.can_add:

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -53,7 +53,7 @@ Attendee.cost_changes = {
 Attendee.credit_changes = {
     'paid': ('Badge Comp', "calc_badge_comp_change"),
     'birthdate': ('Age Discount', "calc_age_discount_change"),
-    'promo_code': ('Promo Code'), # TODO
+    #'promo_code': ('Promo Code'), TODO
 }
 
 @cost_calculation.Attendee

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -145,10 +145,6 @@ def set_cost(group):
         return ("Custom fee for group {}".format(group.name), group.cost * 100)
 
 
-@cost_calculation.PrintJob
-def badge_reprint_fee_cost(job):
-    return ("Badge reprint fee", job.print_fee * 100) if job.print_fee else None
-
 @cost_calculation.Attendee
 def promo_code_group_cost(attendee):
     cost_table = defaultdict(int)

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 from uber.config import c
 from uber.decorators import cost_calculation, credit_calculation
-from uber.models import Attendee
+from uber.models import Attendee, ArtShowApplication, Group
 
 
 @cost_calculation.MarketplaceApplication
@@ -16,6 +16,14 @@ def app_cost(app):
     if app.status == c.APPROVED:
         return ("Marketplace Application Fee", app.overridden_price * 100 or c.MARKETPLACE_FEE * 100 or 0)
 
+
+ArtShowApplication.cost_changes = {
+    'overridden_price': ('Custom App Price', "calc_app_price_change"),
+    'panels': ('General Panels', "calc_app_price_change"),
+    'panels_ad': ('Mature Panels', "calc_app_price_change"),
+    'tables': ('General Tables', "calc_app_price_change"),
+    'tables_ad': ('Mature Tables', "calc_app_price_change"),
+}
 
 @cost_calculation.ArtShowApplication
 def overridden_app_cost(app):
@@ -105,6 +113,12 @@ def group_discount(attendee):
                 attendee.promo_code_groups or attendee.group):
         return ("Group Discount", c.GROUP_DISCOUNT * 100 * -1)
 
+
+Group.cost_changes = {
+    'cost': ('Custom Group Price', "calc_group_price_change"),
+    'tables': ('Tables', "calc_group_price_change"),
+    'badges': ('Badges', "calc_group_price_change"),
+}
 
 @cost_calculation.Group
 def table_cost(group):

--- a/uber/site_sections/art_show_admin.py
+++ b/uber/site_sections/art_show_admin.py
@@ -29,6 +29,8 @@ class Root:
         if new_app and 'attendee_id' in params:
             app = session.art_show_application(params, ignore_csrf=True, bools=['us_only'])
         else:
+            if cherrypy.request.method == 'POST':
+                message = session.auto_update_receipt(session.art_show_application(params.get('id')), params)
             app = session.art_show_application(params, bools=['us_only'])
         attendee = None
         app_paid = 0 if new_app else app.amount_paid
@@ -43,10 +45,11 @@ class Root:
         if cherrypy.request.method == 'POST':
             if new_app:
                 attendee, message = \
-                    session.attendee_from_art_show_app( **params)
+                    session.attendee_from_art_show_app(**params)
             else:
                 attendee = app.attendee
             message = message or check(app)
+
             if not message:
                 if attendee:
                     if params.get('badge_status', ''):

--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -101,6 +101,9 @@ class Root:
                 txns_marked_paid = txn.check_paid_from_stripe()
                 if not txns_marked_paid:
                     last_incomplete_txn = txn
+            session.refresh(receipt)
+        
+        session.refresh(app)
 
         return {
             'message': message,

--- a/uber/site_sections/attractions.py
+++ b/uber/site_sections/attractions.py
@@ -138,8 +138,8 @@ class Root:
         if not attendee:
             raise HTTPRedirect('index')
         if attendee.amount_unpaid:
-            raise HTTPRedirect(
-                '{}?id={}', attendee.payment_page, attendee.id)
+            raise HTTPRedirect('../preregistration/new_badge_payment?id=' + attendee.id + 
+                               '&return_to=../attractions/manage?id=' + attendee.id)
         return {
             'attractions': session.query(Attraction).order_by('name').all(),
             'attendee': attendee,

--- a/uber/site_sections/badge_printing.py
+++ b/uber/site_sections/badge_printing.py
@@ -7,7 +7,7 @@ from uber.config import c
 from uber.custom_tags import time_day_local
 from uber.decorators import ajax, ajax_gettable, all_renderable, not_site_mappable
 from uber.errors import HTTPRedirect
-from uber.models import Attendee, PrintJob
+from uber.models import AdminAccount, Attendee, PrintJob, ReceiptItem
 from uber.utils import localized_now
 
 
@@ -146,6 +146,17 @@ class Root:
         success, message = pre_print_check(session, attendee, printer_id, dry_run=False, **params)
 
         if success:
+            reprint_fee = int(params.get('fee_amount', 0))
+            if reprint_fee:
+                receipt = session.get_receipt_by_model(attendee, create_if_none=True)
+                session.add(ReceiptItem(receipt_id=receipt.id,
+                                        desc="Badge reprint fee (${})".format(reprint_fee),
+                                        amount=reprint_fee * 100,
+                                        count=1,
+                                        who=AdminAccount.admin_name() or 'non-admin',
+                                        )
+                            )
+
             session.add(attendee)
             session.commit()
 
@@ -201,6 +212,16 @@ class Root:
             success = True
             message = "Job marked as invalid."
             job.errors = "Marked invalid by {}".format(session.admin_attendee().full_name)
+            if job.print_fee and job.attendee:
+                receipt = session.get_receipt_by_model(job.attendee)
+                if receipt:
+                    session.add(ReceiptItem(receipt_id=receipt.id,
+                                            desc="Badge reprint cancelled (${})".format(job.print_fee),
+                                            amount=job.print_fee * 100 * -1,
+                                            count=1,
+                                            who=AdminAccount.admin_name() or 'non-admin',
+                                            )
+                                )
             session.add(job)
             session.commit()
         

--- a/uber/site_sections/group_admin.py
+++ b/uber/site_sections/group_admin.py
@@ -43,11 +43,14 @@ class Root:
 
     @log_pageview
     def form(self, session, new_dealer='', message='', **params):
+        if cherrypy.request.method == 'POST':
+                message = session.auto_update_receipt(session.group(params.get('id')), params)
+
         group = session.group(params, checkgroups=Group.all_checkgroups, bools=Group.all_bools)
 
         if cherrypy.request.method == 'POST':
             new_with_leader = any(params.get(info) for info in ['first_name', 'last_name', 'email'])
-            message = self._required_message(params, ['name'])
+            message = message or self._required_message(params, ['name'])
             
             if not message and group.is_new and (params.get('group_type') or new_dealer or group.is_dealer):
                 message = self._required_message(params, ['first_name', 'last_name', 'email'])
@@ -71,8 +74,7 @@ class Root:
                     badge_status=new_badge_status,
                     )
 
-            if not message:
-                if group.is_new and new_with_leader:
+            if not message and group.is_new and new_with_leader:
                     session.commit()
                     leader = group.leader = group.attendees[0]
                     leader.first_name = params.get('first_name')
@@ -84,22 +86,22 @@ class Root:
                         session.delete(group)
                         session.commit()
 
-                if not message:
-                    if params.get('group_type'):
-                        group.guest = group.guest or GuestGroup()
-                        group.guest.group_type = params.get('group_type')
+            if not message:
+                if params.get('group_type'):
+                    group.guest = group.guest or GuestGroup()
+                    group.guest.group_type = params.get('group_type')
+                
+                if group.is_new and group.is_dealer:
+                    if group.status == c.APPROVED and group.amount_unpaid:
+                        raise HTTPRedirect('../preregistration/group_members?id={}', group.id)
+                    elif group.status == c.APPROVED:
+                        raise HTTPRedirect(
+                            'index?message={}', group.name + ' has been uploaded and approved')
+                    else:
+                        raise HTTPRedirect(
+                            'index?message={}', group.name + ' is uploaded as ' + group.status_label)
                     
-                    if group.is_new and group.is_dealer:
-                        if group.status == c.APPROVED and group.amount_unpaid:
-                            raise HTTPRedirect('../preregistration/group_members?id={}', group.id)
-                        elif group.status == c.APPROVED:
-                            raise HTTPRedirect(
-                                'index?message={}', group.name + ' has been uploaded and approved')
-                        else:
-                            raise HTTPRedirect(
-                                'index?message={}', group.name + ' is uploaded as ' + group.status_label)
-                     
-                    raise HTTPRedirect('form?id={}&message={} has been saved', group.id, group.name)
+                raise HTTPRedirect('form?id={}&message={} has been saved', group.id, group.name)
 
         return {
             'message': message,

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -943,8 +943,10 @@ class Root:
                 txns_marked_paid = txn.check_paid_from_stripe()
                 if not txns_marked_paid:
                     last_incomplete_txn = txn
+            session.refresh(receipt)
 
-            session.commit()
+        session.refresh(group)
+
         return {
             'group':   group,
             'account': session.get_attendee_account_by_attendee(group.leader),
@@ -1375,8 +1377,9 @@ class Root:
                 txns_marked_paid = txn.check_paid_from_stripe()
                 if not txns_marked_paid:
                     last_incomplete_txn = txn
+            session.refresh(receipt)
 
-            session.commit()
+        session.refresh(attendee)
 
         return {
             'undoing_extra': undoing_extra,

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1001,7 +1001,7 @@ class Root:
 
                 attendee.apply(params, restricted=True)
 
-                if c.ATTENDEE_ACCOUNTS_ENABLED:
+                if c.ATTENDEE_ACCOUNTS_ENABLED and session.current_attendee_account():
                     session.add_attendee_to_account(attendee, session.current_attendee_account())
 
                 # Free group badges are considered 'registered' when they are actually claimed.
@@ -1316,7 +1316,7 @@ class Root:
             message = "Something went wrong. Please try again."
         if not attendee.email:
             message = "This attendee needs an email address to set up a new account."
-        if normalize_email(attendee.email) == session.current_attendee_account().normalized_email:
+        if session.current_attendee_account() and normalize_email(attendee.email) == session.current_attendee_account().normalized_email:
             message = "You cannot grant an account to someone with the same email address as your account."
         if not message:
             set_up_new_account(session, attendee)

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1009,7 +1009,7 @@ class Root:
                     attendee.registered = localized_now()
 
                 if attendee.amount_unpaid:
-                    raise HTTPRedirect(attendee.payment_page)
+                    raise HTTPRedirect('new_badge_payment?id={}&return_to=confirm', attendee.id)
                 else:
                     raise HTTPRedirect('badge_updated?id={}&message={}', attendee.id, 'Badge registered successfully')
 
@@ -1150,7 +1150,7 @@ class Root:
                     log.error('unable to send badge change email', exc_info=True)
 
                 if attendee.amount_unpaid:
-                    raise HTTPRedirect(attendee.payment_page)
+                    raise HTTPRedirect('new_badge_payment?id={}&return_to=confirm', attendee.id)
                 else:
                     raise HTTPRedirect(
                         'badge_updated?id={}&message={}', attendee.id, 'Your registration has been transferred')
@@ -1182,7 +1182,7 @@ class Root:
                 session.commit()
 
                 if attendee.amount_unpaid:
-                    raise HTTPRedirect(attendee.payment_page + '&payment_label=merch_shipping_fee')
+                    raise HTTPRedirect('new_badge_payment?id={}&return_to=confirm', attendee.id)
                 else:
                     raise HTTPRedirect(
                         'badge_updated?id={}&message={}', attendee.id, 'Your registration has been deferred')

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -570,7 +570,9 @@ class Root:
     def register(self, session, message='', error_message='', **params):
         params['id'] = 'None'
         login_email = None
-        payment_method = int(params.get('payment_method', 0))
+        payment_method = params.get('payment_method')
+        if payment_method:
+            payment_method = int(payment_method)
 
         if 'kiosk_mode' in params:
             cherrypy.session['kiosk_mode'] = True
@@ -638,7 +640,7 @@ class Root:
             'message':  message,
             'error_message':  error_message,
             'attendee': attendee,
-            'payment_method': payment_method,
+            'payment_method_val': payment_method,
             'promo_code': params.get('promo_code', ''),
             'logged_in_account': session.current_attendee_account(),
             'original_location': '../registration/register',

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -206,6 +206,9 @@ class Root:
         if receipt:
             for txn in receipt.pending_txns:
                 txn.check_paid_from_stripe()
+            session.refresh(receipt)
+
+        session.refresh(attendee)
 
         return {
             'message':    message,
@@ -480,6 +483,9 @@ class Root:
         if receipt:
             for txn in receipt.pending_txns:
                 txn.check_paid_from_stripe()
+            session.refresh(receipt)
+
+        session.refresh(attendee)
 
         if attendee.paid == c.PAID_BY_GROUP and not attendee.group_id:
             valid_groups = session.query(Group).options(joinedload(Group.leader)).filter(

--- a/uber/templates/badge_printing/queue_badge.html
+++ b/uber/templates/badge_printing/queue_badge.html
@@ -54,7 +54,11 @@ printBadge = function ($form) {
         data: $form.serialize(),
         success: function (json) {
             if (json.success) {
-            toastr.success(json.message);
+                if (json.message.includes('fee')) { 
+                    window.location = window.location + '&message=' + json.message
+                } else {
+                    toastr.success(json.message);
+                }
             } else {
             toastr.error(json.message);
             }

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -1764,7 +1764,7 @@ $(window).on("runJavaScript", function(){
       {% else %}
         <select name="payment_method" class="form-control" onChange="maybeBold()">
           <option value="">Select a payment option</option>
-          {{ options(c.DOOR_PAYMENT_METHOD_OPTS,payment_method) }}
+          {{ options(c.DOOR_PAYMENT_METHOD_OPTS, payment_method_val) }}
         </select>
         {% if c.CHILD_BADGE in c.PREREG_BADGE_TYPES %}
         <div class="form-group">

--- a/uber/templates/fields/attendee.html
+++ b/uber/templates/fields/attendee.html
@@ -818,7 +818,7 @@ $().ready(function() {
 
 {% set shirt_size %}
 {% set read_only = shirt_size_ro or page_ro %}
-{% if not admin_area or attendee.num_event_shirts_owed or attendee.gets_staff_shirt and c.STAFF_SHIRT_OPTS == c.SHIRT_OPTS %}
+{% if not admin_area or c.BADGE_TYPE_PRICES or attendee.num_event_shirts_owed or attendee.gets_staff_shirt and c.STAFF_SHIRT_OPTS == c.SHIRT_OPTS %}
   {% set shirt_opts = c.PREREG_SHIRT_OPTS if not admin_area else c.SHIRT_OPTS %}
   {% set warn_on_change = c.PREREG_SHIRTS and not admin_area and attendee.shirt not in c.PREREG_SHIRTS.keys() %}
   {% if not admin_area %}

--- a/uber/templates/fields/group.html
+++ b/uber/templates/fields/group.html
@@ -120,7 +120,7 @@
 
 
 {% set group_name %}
-{% set read_only = group_name_ro or page_ro %}
+{% set read_only = (group_name_ro or page_ro) and not (group.status == c.APPROVED and 'name' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="group_fields">
   <div class="form-group">
     <label for="name" class="col-sm-3 control-label">{{ "Table" if attendee_or_group.is_dealer else "Group" }} Name</label>
@@ -224,7 +224,7 @@
 
 
 {% set categories %}
-{% set read_only = categories_ro or page_ro %}
+{% set read_only = (categories_ro or page_ro) and not (group.status == c.APPROVED and 'categories' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="form-group">
   <label for="categories" class="col-sm-3 control-label">What kinds of things do you sell?</label>
   {% call macros.read_only_if(read_only, 
@@ -254,7 +254,7 @@
 
 
 {% set wares %}
-{% set read_only = wares_ro or page_ro %}
+{% set read_only = (wares_ro or page_ro) and not (group.status == c.APPROVED and 'wares' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="form-group">
   <label for="wares" class="col-sm-3 control-label">What do you sell?</label>
   {% call macros.read_only_if(read_only, group.wares, check_dealer_editable=(group, 'wares')) %}
@@ -270,7 +270,7 @@
 
 
 {% set description %}
-{% set read_only = description_ro or page_ro %}
+{% set read_only = (description_ro or page_ro) and not (group.status == c.APPROVED and 'description' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="form-group">
   <label for="description" class="col-sm-3 control-label">Description</label>
   {% call macros.read_only_if(read_only, group.description, check_dealer_editable=(group, 'description')) %}
@@ -286,7 +286,7 @@
 
 
 {% set special_needs %}
-{% set read_only = special_needs_ro or page_ro %}
+{% set read_only = (special_needs_ro or page_ro) and not (group.status == c.APPROVED and 'special_needs' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="form-group">
   <label for="special_needs" class="col-sm-3 control-label optional-field">Table Requests and Special Requests</label>
   {% call macros.read_only_if(read_only, group.special_needs, check_dealer_editable=(group, 'special_needs')) %}
@@ -302,7 +302,7 @@
 
 
 {% set website %}
-{% set read_only = website_ro or page_ro %}
+{% set read_only = (website_ro or page_ro) and not (group.status == c.APPROVED and 'website' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 <div class="form-group">
   <label for="website" class="col-sm-3 control-label">Website URL</label>
   {% call macros.read_only_if(read_only, group.website, check_dealer_editable=(group, 'website')) %}
@@ -318,7 +318,7 @@
 
 
 {% set address %}
-{% set read_only = group_address_ro or page_ro %}
+{% set read_only = (group_address_ro or page_ro) and not (group.status == c.APPROVED and 'address' in c.APPROVED_DEALER_EDITABLE_FIELDS) %}
 {% set required = not admin_area %}
 {% set prefix = '' if 'group_admin' in c.PAGE_PATH else 'group_' %}
 {% if not read_only %}

--- a/uber/templates/model_history_base.html
+++ b/uber/templates/model_history_base.html
@@ -22,30 +22,6 @@
     {% endfor %}
   </table>
 
-  {% if model.stripe_txn_share_logs %}
-    <h2>Payment History for {{ model.full_name|default(model.name) }} {% if c.AT_THE_CON and model.badge_num %}({{ model.badge_num }}){% endif %}</h2>
-    <table class="table-striped table-bordered table-condensed">
-      <thead><tr>
-        <th>Payment ID</th>
-        <th>Amount</th>
-        <th>Txn Total</th>
-        <th>When</th>
-        <th>Who</th>
-        <th>Description</th>
-      </tr></thead>
-      {% for log in model.stripe_txn_share_logs %}
-        <tr>
-          <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.stripe_id }}</td>
-          <td valign="top" style="white-space:nowrap">{{ (log.share / 100)|format_currency }}
-          <td valign="top" style="white-space:nowrap">{{ (log.stripe_transaction.amount / 100)|format_currency }} {{ log.stripe_transaction.type_label }}</td>
-          <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.when|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
-          <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.who }}</td>
-          <td valign="top" style="white-space:nowrap">{{ log.stripe_transaction.desc }}</td>
-        </tr>
-      {% endfor %}
-    </table>
-  {% endif %}
-
   <h2>Page View History for {{ model.full_name|default(model.name) }} {% if c.AT_THE_CON and model.badge_num %}({{ model.badge_num }}){% endif %}</h2>
 
   <table class="table-striped table-bordered table-condensed">

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -172,7 +172,7 @@
         Please contact us at <strong>{{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}</strong> if you wish to purchase additional badges.
         {% endif %}
 
-{% if c.PRE_CON and group.min_badges_addable %}
+{% if group.min_badges_addable %}
     <div id="add" style="display:none">
       <form class="form-inline" method="get" action="add_group_members">
         <input type="hidden" name="id" value="{{ group.id }}" />

--- a/uber/templates/preregistration/group_promo_codes.html
+++ b/uber/templates/preregistration/group_promo_codes.html
@@ -55,7 +55,7 @@
 
     <br/>
 
-    {% if c.PRE_CON %}
+    {% if group.min_badges_addable %}
       <div id="add" style="display:none">
         <form class="form-inline" method="get" action="add_promo_codes">
           <input type="hidden" name="id" value="{{ group.id }}" />

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -427,7 +427,7 @@
     {% if not receipt.closed %}
     <tr id="{{ receipt.id }}">
       <td colspan="7">
-        <div class="btn-group pull-right" role="group" aria-label="...">
+        <div class="btn-group pull-right" role="group">
           <button class="btn btn-default">Add:</button>
           <button class="btn btn-primary" onClick="showForm('{{ receipt.id }}', '-purchase-form')">Purchase</button>
           <button class="btn btn-success" onClick="showForm('{{ receipt.id }}', '-credit-form')">Credit</button>

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -409,7 +409,7 @@
               </button>
             {% endif %}
           {% elif item.charge_id and amount_left and not receipt.closed %}
-            <button class="btn btn-sm btn-success" onClick="refundTxn('{{ item.id }}', '{{ (amount_left / 100)|format_currency }}')">Refund Transaction</button>
+            <button class="btn btn-sm btn-warning" onClick="refundTxn('{{ item.id }}', '{{ (amount_left / 100)|format_currency }}')">Refund Transaction</button>
             <span id="amt-refunded">{% if item.refunded %} ({{ (item.refunded / 100)|format_currency }} refunded){% endif %}</span>
           {% endif %}
         </td>

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -22,7 +22,7 @@
   };
   var updateTotal = function (text, disable_button=true) {
     $('#receipt_total').html(text);
-    $('#record_payment_refund').prop('disabled', disable_button);
+    $('.record_payment_refund').prop('disabled', disable_button);
   }
   var showForm = function(receiptId, whichForm) {
     $('#' + receiptId + whichForm).removeClass('hidden')
@@ -127,10 +127,11 @@
   };
 
   var refundTxn = function (txnId, amount) {
-    bootbox.confirm({
+    var refundPrompt = bootbox.prompt({
       title: "Refund Transaction?",
-      message: "This will refund the attendee " + amount + " through Stripe. " +
+      message: "This will refund the attendee through Stripe. " +
         "This cannot be undone. Are you sure?",
+      placeholder: amount,
       buttons: {
           confirm: {
               label: 'Refund',
@@ -143,18 +144,22 @@
       },
       callback: function (result) {
         if(result) {
-          $.post('refund_receipt_txn', {csrf_token: csrf_token, id: txnId}, function (response) {
+          $.post('refund_receipt_txn', {csrf_token: csrf_token, id: txnId, amount: result}, function (response) {
             toastr.clear();
             if (response.error) {
               toastr.error(response.error);
             } else {
               toastr.info('Transaction refunded');
-              updateRow(response.refunded, ' td:last', "<em>Transaction refunded.</em>");
+              updateRow(response.refunded, ' td:last #amt-refunded', " ($" + (response.refund_total / 100).toFixed(2) + " refunded)");
               updateTotal(response.new_total, response.disable_button);
             }
           }, 'json');
         }
       }
+    });
+    refundPrompt.init(function(){
+      $(this).find('.bootbox-form').prepend('<p>This will refund the attendee through Stripe. You can enter an amount below or leave it blank to refund the full amount.</p>')
+      $(this).find('.bootbox-input-text')
     });
   };
 
@@ -265,21 +270,16 @@
   {% include "registration/menu.html" if attendee else "group_admin/nav_menu.html" %}
 {% endif %}
 
-<h2>Receipt{% if other_receipts %}s{% endif %} for {% if model.attendee %}{{ model.attendee.full_name }}'s {{ model_str|title }}{% else %}{{ model.full_name|default(model.name) }}{% endif %}{% if c.AT_THE_CON and model.badge_num %}({{ model.badge }}){% endif %}</h2>
+<h2>Receipt{% if other_receipts %}s{% endif %} for {% if model.attendee %}{{ model.attendee.full_name }}'s {{ model_str|title }}{% else %}{{ model.full_name|default(model.name) }}{% endif %}{% if c.AT_THE_CON and model.badge_num %} ({{ model.badge }}){% endif %}</h2>
   <div class="panel panel-body">
   <p>Use this form to remove and add custom purchases and credits or non-Stripe payments and refunds for this {{ model_str }}.
-    You will not be able to remove purchases or credits that were created before a sucessful payment was made.
+    You will not be able to remove purchases or credits that were created before a successful payment was made.
     Confirmed Stripe payments or refunds that have a Stripe ID will also be locked.
-  </p>
-
-  <p>
-    Enter a positive number in the amount field to add a purchase, and a negative number to apply a credit.
-    Similarly, payments and refunds can be tracked using positive and negative amounts, respectively.
   </p>
   
   <p>
     If a payment was made and confirmed through Stripe, you can refund part or all of it using the "Refund Transaction" button.
-    Note that some Stripe payments may appear on multiple receipts, for example, when somone registers multiple badges in one transaction.
+    Note that some Stripe payments may appear on multiple receipts, for example, when someone registers multiple badges in one transaction.
   </p>
 
   <p>
@@ -288,7 +288,75 @@
   </p>
   </div>
 
+{% macro receipt_item_form(type="purchase") %}
+<tr id="{{ receipt.id }}-{{ type }}-form" class="hidden">
+  <td colspan="7">
+    <button type="button" class="close pull-left" aria-label="Close" onClick="hideForm('{{ receipt.id }}', '-{{ type }}-form')"><span aria-hidden="true">&times;</span></button>
+    <form method="post" action="add_receipt_item" class="form-inline pull-right">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ receipt.id }}" />
+      <input type="hidden" name="item_type" value="{{ type }}" />
+      <div class="form-group">
+        <label for="desc">Description</label>
+        <input type="text" name="desc" class="form-control" placeholder="{{ type|title }} Description" required>
+      </div>
+      <div class="form-group">
+        <label for="amount">Amount</label>
+        <div class="input-group">
+          <span class="input-group-addon">$</span>
+          <input type="number" name="amount" class="form-control" placeholder="0" required>
+          <span class="input-group-addon">.00</span>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="count">Quantity</label>
+          <input type="number" name="count" class="form-control" placeholder="1">
+      </div>
+      <button type="submit" class="btn {{ 'btn-primary' if type == 'purchase' else 'btn-success' }}">Add {{ type|title }}</button>
+    </form>
+  </td>
+</tr>
+{% endmacro %}
+{% macro receipt_txn_form(type="payment") %}
+<tr id="{{ receipt.id }}-{{ type }}-form" class="hidden">
+  <td colspan="7">
+    <button type="button" class="close pull-left" aria-label="Close" onClick="hideForm('{{ receipt.id }}', '-{{ type }}-form')"><span aria-hidden="true">&times;</span></button>
+    <form method="post" action="add_receipt_txn" class="form-inline pull-right">
+      {{ csrf_token() }}
+      <input type="hidden" name="id" value="{{ receipt.id }}" />
+      <input type="hidden" name="txn_type" value="{{ type }}" />
+      <div class="form-group">
+        <label for="amount">{{ type|title }} Method</label>
+        <select name="method" class="form-control">
+          <option value="">Select a Method</option>
+          {{ options(c.PAYMENT_METHOD_OPTS, c.CASH) }}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="count">Amount</label>
+        <div class="input-group">
+          <span class="input-group-addon">$</span>
+          <input type="number" name="amount" class="form-control" placeholder="0" required>
+          <span class="input-group-addon">.00</span>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="desc">Description</label>
+        <input type="text" name="desc" class="form-control" placeholder="Transaction Description">
+      </div>
+      <button type="submit" class="btn {{ 'btn-info' if type == 'payment' else 'btn-warning' }}">Add {{ type|title }}</button>
+    </form>
+  </td>
+</tr>
+  {% endmacro %}
+
 {% macro receipt_table(receipt, items) %}
+<ul class="nav nav-tabs" role="tablist">
+  <li role="presentation" class="active"><a href="#{{ receipt.id }}-home" aria-controls="{{ receipt.id }}-home" role="tab" data-toggle="tab">Receipt</a></li>
+  <li role="presentation"><a href="#{{ receipt.id }}-history" aria-controls="{{ receipt.id }}-history" role="tab" data-toggle="tab">History</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="{{ receipt.id }}-home">
   <table class="table table-striped">
     <thead><tr>
       <th>Added</th>
@@ -299,6 +367,7 @@
       <th></th>
     </tr></thead>
     {% for item in items %}
+    {% set amount_left = item.amount - item.refunded if item.refunded else item.amount %}
       <tr id="{{ item.id }}">
         <td>{{ item.added|datetime_local("%b %-d %-H:%M (%-I:%M%p)") }}</td>
         <td>{{ item.who }}</td>
@@ -328,7 +397,8 @@
           {% elif item.is_pending_charge or not item.stripe_id %}
             {% if item.intent_id and not item.refund_id and not receipt.closed %}
               <button class="btn btn-sm btn-danger" onClick="cancelTxn('{{ item.id }}')">Mark as Cancelled</button>
-            {% elif item.method and not receipt.open_receipt_items|selectattr("added", "<", item.added)|list|length %}
+            {# This should be updated when we associate receipt txns with items directly #}
+            {% elif item.method and not receipt.open_receipt_items|selectattr("added", "<", item.added)|list|length and receipt.current_receipt_amount == 0 %}
               <em>Payment locked.</em>
             {% elif not receipt.closed %}
               {% if item.revert_change %}
@@ -338,10 +408,9 @@
                 Delete {{ "Transaction" if item.method else "Item" }}
               </button>
             {% endif %}
-          {% elif item.refund_id and (item.refunded or item.amount > 0) %}
-              <em>{% if item.refunded %}{{ item.refunded|format_currency }}{% else %}Transaction{% endif %} refunded.</em>
-          {% elif item.charge_id and not item.refund_id and not receipt.closed %}
-            <button class="btn btn-sm btn-success" onClick="refundTxn('{{ item.id }}', '{{ (item.amount / 100)|format_currency }}')">Refund Transaction</button>
+          {% elif item.charge_id and amount_left and not receipt.closed %}
+            <button class="btn btn-sm btn-success" onClick="refundTxn('{{ item.id }}', '{{ (amount_left / 100)|format_currency }}')">Refund Transaction</button>
+            <span id="amt-refunded">{% if item.refunded %} ({{ (item.refunded / 100)|format_currency }} refunded){% endif %}</span>
           {% endif %}
         </td>
       </tr>
@@ -351,72 +420,46 @@
         <span class="pull-right"><strong>Total</strong>: <span id="receipt_total">{{ receipt.total_str }}</span></span>
       </td>
     </tr>
-    <tr id="{{ receipt.id }}-item-form" class="hidden">
-      <td colspan="7">
-        <button type="button" class="close pull-left" aria-label="Close" onClick="hideForm('{{ receipt.id }}', '-item-form')"><span aria-hidden="true">&times;</span></button>
-        <form method="post" action="add_receipt_item" class="form-inline pull-right">
-          {{ csrf_token() }}
-          <input type="hidden" name="id" value="{{ receipt.id }}" />
-          <div class="form-group">
-            <label for="desc">Description</label>
-            <input type="text" name="desc" class="form-control" placeholder="Item Description" required>
-          </div>
-          <div class="form-group">
-            <label for="amount">Amount</label>
-            <div class="input-group">
-              <span class="input-group-addon">$</span>
-              <input type="number" name="amount" class="form-control" placeholder="0" required>
-              <span class="input-group-addon">.00</span>
-            </div>
-          </div>
-          <div class="form-group">
-            <label for="count">Quantity</label>
-              <input type="number" name="count" class="form-control" placeholder="1">
-          </div>
-          <button type="submit" class="btn btn-primary">Add Purchase/Credit</button>
-        </form>
-      </td>
-    </tr>
-    <tr id="{{ receipt.id }}-txn-form" class="hidden">
-      <td colspan="7">
-        <button type="button" class="close pull-left" aria-label="Close" onClick="hideForm('{{ receipt.id }}', '-txn-form')"><span aria-hidden="true">&times;</span></button>
-        <form method="post" action="add_receipt_txn" class="form-inline pull-right">
-          {{ csrf_token() }}
-          <input type="hidden" name="id" value="{{ receipt.id }}" />
-          <div class="form-group">
-            <label for="amount">Payment/Refund Method</label>
-            <select name="method" class="form-control">
-              <option value="">Select a Method</option>
-              {{ options(c.PAYMENT_METHOD_OPTS, c.CASH) }}
-            </select>
-          </div>
-          <div class="form-group">
-            <label for="count">Amount</label>
-            <div class="input-group">
-              <span class="input-group-addon">$</span>
-              <input type="number" name="amount" class="form-control" placeholder="0" required>
-              <span class="input-group-addon">.00</span>
-            </div>
-          </div>
-          <div class="form-group">
-            <label for="desc">Description</label>
-            <input type="text" name="desc" class="form-control" placeholder="Transaction Description">
-          </div>
-          <button type="submit" class="btn btn-success">Add Payment/Refund</button>
-        </form>
-      </td>
-    </tr>
+    {{ receipt_item_form(type="purchase") }}
+    {{ receipt_item_form(type="credit") }}
+    {{ receipt_txn_form(type="payment") }}
+    {{ receipt_txn_form(type="refund") }}
     {% if not receipt.closed %}
     <tr id="{{ receipt.id }}">
       <td colspan="7">
         <div class="btn-group pull-right" role="group" aria-label="...">
-          <button class="btn btn-primary" onClick="showForm('{{ receipt.id }}', '-item-form')">Add Custom Purchase or Credit</button>
-          <button class="btn btn-success" id="record_payment_refund" onClick="showForm('{{ receipt.id }}', '-txn-form')"{% if receipt.current_receipt_amount == 0 %} disabled{% endif %}>Record Payment or Refund</button>
+          <button class="btn btn-default">Add:</button>
+          <button class="btn btn-primary" onClick="showForm('{{ receipt.id }}', '-purchase-form')">Purchase</button>
+          <button class="btn btn-success" onClick="showForm('{{ receipt.id }}', '-credit-form')">Credit</button>
+          <button class="btn btn-info record_payment_refund" onClick="showForm('{{ receipt.id }}', '-payment-form')"{% if receipt.current_receipt_amount == 0 %} disabled{% endif %}>Payment</button>
+          <button class="btn btn-warning record_payment_refund" onClick="showForm('{{ receipt.id }}', '-refund-form')"{% if receipt.current_receipt_amount == 0 %} disabled{% endif %}>Refund</button>
         </div>
       </td>
     </tr>
     {% endif %}
   </table>
+</div>
+<div role="tabpanel" class="tab-pane" id="{{ receipt.id }}-history">
+  <table class="table-striped table-bordered table-condensed">
+    <thead><tr>
+      <th>Which</th>
+      <th>What</th>
+      <th>When</th>
+      <th>Who</th>
+      <th>Changes</th>
+    </tr></thead>
+    {% for tracked in receipt.changes %}
+      <tr>
+        <td valign="top" style="white-space:nowrap">{{ tracked.model }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.action_label }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.when|full_datetime_local }}</td>
+        <td valign="top" style="white-space:nowrap">{{ tracked.who }}</td>
+        <td valign="top">{{ tracked.data }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+</div>
+</div>
 {% endmacro %}
 
 <div class="panel panel-default">

--- a/uber/templates/registration/at_door_complete.html
+++ b/uber/templates/registration/at_door_complete.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% import "fields/attendee.html" as attendee_fields with context %}
+{% block title %}At the Door Registration{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+
+{% include 'prereg_masthead.html' %}
+  <div class="panel panel-default">
+    <div class="panel-body">
+        <div class="alert alert-success">{{ confirm_message }}</div>
+        <a class="btn btn-primary" href="register">Register Another Badge</a> or <a class="btn btn-default" href="../preregistration/homepage">Go to Homepage</a>
+    </div>
+</div>
+{% endblock %}

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -12,7 +12,7 @@
 <input type="hidden" name="id" value="{{ attendee.id }}" />
 <select name="payment_method" onChange="toggleMarkButton(this)">
     <option value="">Payment Method</option>
-    {{ options(c.NEW_REG_PAYMENT_METHOD_OPTS,attendee.payment_method) }}
+    {{ options(c.NEW_REG_PAYMENT_METHOD_OPTS,payment_method) }}
 </select>
     <button class="btn btn-success" type="submit" disabled="disabled">Mark as Paid</button>
 </form>

--- a/uber/templates/registration/check_in_form_base.html
+++ b/uber/templates/registration/check_in_form_base.html
@@ -226,15 +226,17 @@ $().ready(function() {
                      * keypress handler on the element.
                      */
                     var focusBadgeNum = function () {
-                        var $num = $('#checkin-badge:text');
-                        if ($num.is(':visible')) {
-                            $num.focus().keypress(function (event) {
-                                if (event.keyCode === 13) {
-                                    checkIn('{{ attendee.id }}');
-                                }
-                            });
-                        } else {
-                            setTimeout(focusBadgeNum, 100);
+                        if($('input#checkin-badge')) {
+                            var $num = $('#checkin-badge:text');
+                            if ($num.is(':visible')) {
+                                $num.focus().keypress(function (event) {
+                                    if (event.keyCode === 13) {
+                                        checkIn('{{ attendee.id }}');
+                                    }
+                                });
+                            } else {
+                                setTimeout(focusBadgeNum, 100);
+                            }
                         }
                     };
                     focusBadgeNum();
@@ -336,9 +338,9 @@ $().ready(function() {
     };
 
     age = {{ attendee.age_now_or_at_con|default(0, true)}};
-    if (age < 18) {
+    if (age < 18 && $.field('printer_id')) {
         $.field('printer_id').val(printer_minor_id);
-    } else if (age >= 18) {
+    } else if (age >= 18 && $.field('printer_id')) {
         $.field('printer_id').val(printer_default_id);
     }
 </script>

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -88,9 +88,7 @@
         <input class="form-control" id="reg_station" name="reg_station" placeholder="Reg Station #" value="{{ reg_station }}">
         <button type="submit" class="btn btn-primary">Save</button>
         </span>
-        {% if c.HAS_MERCH_ADMIN_ACCESS %}
         <a href="../merch_admin/arbitrary_charge_form" target="_blank" class="btn btn-warning">Arbitrary Charge Form</a>
-        {% endif %}
         </div>
       </form>
     </div>

--- a/uber/templates/registration/index_base.html
+++ b/uber/templates/registration/index_base.html
@@ -88,6 +88,9 @@
         <input class="form-control" id="reg_station" name="reg_station" placeholder="Reg Station #" value="{{ reg_station }}">
         <button type="submit" class="btn btn-primary">Save</button>
         </span>
+        {% if c.HAS_MERCH_ADMIN_ACCESS %}
+        <a href="../merch_admin/arbitrary_charge_form" target="_blank" class="btn btn-warning">Arbitrary Charge Form</a>
+        {% endif %}
         </div>
       </form>
     </div>

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1185,7 +1185,7 @@ class Charge:
         except Exception:
             pass # It's fine if this is not a number
 
-        if isinstance(model.__table__.columns.get(col_name).type, Choice):
+        if col_name != 'badges' and isinstance(model.__table__.columns.get(col_name).type, Choice):
             increase_term, decrease_term = "Upgrading", "Downgrading"
         else:
             increase_term, decrease_term = "Increasing", "Decreasing"
@@ -1216,13 +1216,18 @@ class Charge:
         else:
             cost_desc = "{} {}".format(decrease_term, cost_change_name)
 
+        if col_name == 'tables':
+            old_val = int(getattr(model, col_name))
+        else:
+            old_val = getattr(model, col_name)
+
         if receipt:
             return ReceiptItem(receipt_id=receipt.id,
                                 desc=cost_desc,
                                 amount=cost_change,
                                 count=count,
                                 who=AdminAccount.admin_name() or 'non-admin',
-                                revert_change={col_name: getattr(model, col_name)},
+                                revert_change={col_name: old_val},
                             )
         else:
             return (cost_desc, cost_change, count)

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1130,6 +1130,42 @@ class Charge:
         return (model_dict[col_name] * 100, (int(new_val) - model_dict[col_name]) * 100)
 
     @classmethod
+    def process_receipt_credit_change(cls, model, col_name, new_val, receipt=None):
+        from uber.models import AdminAccount, ReceiptItem
+
+        credit_change_tuple = model.credit_changes.get(col_name)
+        if credit_change_tuple:
+            credit_change_name = credit_change_tuple[0]
+            credit_change_func = credit_change_tuple[1]
+
+            change_func = getattr(model, credit_change_func)
+            old_discount, discount_change = change_func(**{col_name: new_val})
+            log.debug(old_discount)
+            log.debug(discount_change)
+            if old_discount >= 0 and discount_change < 0:
+                verb = "Added"
+            elif old_discount < 0 and discount_change >= 0 and old_discount == discount_change * -1:
+                verb = "Removed"
+            else:
+                verb = "Changed"
+            discount_desc = "{} {}".format(credit_change_name, verb)
+            
+            if col_name == 'birthdate':
+                old_val = datetime.strftime(getattr(model, col_name), c.TIMESTAMP_FORMAT)
+            else:
+                old_val = getattr(model, col_name)
+
+            if receipt:
+                return ReceiptItem(receipt_id=receipt.id,
+                                   desc=discount_desc,
+                                   amount=discount_change,
+                                   who=AdminAccount.admin_name() or 'non-admin',
+                                   revert_change={col_name: old_val},
+                                )
+            else:
+                return (discount_desc, discount_change)
+
+    @classmethod
     def process_receipt_upgrade_item(cls, model, col_name, new_val, receipt=None, count=1):
         """
         Finds the cost of a receipt item to add to an existing receipt.


### PR DESCRIPTION
🤞 🤞 🤞 

Includes the following:
- Improves UX of receipt items page, including a history tab for each receipt
- Automatically updates existing receipts for groups, attendees, and art show applications based on admin changes
- Ignores receipts for invalid attendees and groups
- Adds badge reprint fees to receipts when a badge print is queued, and adds a credit if badge print is invalidated
- Adds explicit badge confirmation page for at-door registrations -- this page is skipped in kiosk mode
- Fixes various display bugs for the at-con registration page, check-in modal, admin form, and group management page