### PR TITLE
Fix issue with viewing receiptless attendees

### DIFF
--- a/uber/site_sections/art_show_applications.py
+++ b/uber/site_sections/art_show_applications.py
@@ -100,7 +100,7 @@ class Root:
             'message': message,
             'app': app,
             'receipt': receipt,
-            'incomplete_txn': receipt.last_incomplete_txn,
+            'incomplete_txn': receipt.last_incomplete_txn if receipt else None,
             'account': session.get_attendee_account_by_attendee(app.attendee),
             'return_to': 'edit?id={}'.format(app.id),
         }

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -946,7 +946,7 @@ class Root:
             'signnow_document': signnow_document,
             'signnow_link': signnow_link,
             'receipt': receipt,
-            'incomplete_txn': receipt.last_incomplete_txn,
+            'incomplete_txn': receipt.last_incomplete_txn if receipt else None,
             'message': message
         }
 
@@ -1374,7 +1374,7 @@ class Root:
             'attractions':   session.query(Attraction).filter_by(is_public=True).all(),
             'badge_cost':    attendee.badge_cost if attendee.paid != c.PAID_BY_GROUP else 0,
             'receipt':       session.get_receipt_by_model(attendee) if attendee.is_valid else None,
-            'incomplete_txn':  receipt.last_incomplete_txn,
+            'incomplete_txn':  receipt.last_incomplete_txn if receipt else None,
             'attendee_group_discount': (group_credit[1] / 100) if group_credit else 0,
         }
         


### PR DESCRIPTION
Fixes a bug where attendees, groups, and apps without receipts would generate a 500 error on the attendee side when viewing their respective pages.