### PR TITLE
Account for at-con on attendee homepage

### DIFF
--- a/uber/templates/preregistration/homepage.html
+++ b/uber/templates/preregistration/homepage.html
@@ -7,7 +7,7 @@
 {% set prereg_message %}
     {% if c.BEFORE_PREREG_OPEN %}
         Preregistration will open {{ c.PREREG_OPEN|datetime_local }}.
-    {% elif c.AFTER_PREREG_TAKEDOWN %}
+    {% elif c.AFTER_PREREG_TAKEDOWN and not c.AT_THE_CON %}
         Preregistration has closed for the year.
     {% elif not c.ATTENDEE_BADGE_AVAILABLE %}
         Preregistration has sold out!


### PR DESCRIPTION
Fixes an issue where people would just be told prereg was closed when they logged in.