### PR TITLE
At-con payment fixes

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -968,6 +968,9 @@ class Session(SessionManager):
 
             refund_amount = int(amount or txn.amount - txn.refunded)
 
+            if not refund_amount:
+                return
+
             log.debug('REFUND: attempting to refund Stripe transaction with ID {} {} cents for {}',
                       txn.stripe_id, refund_amount, txn.desc)
 

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -853,6 +853,10 @@ class Attendee(MagModel, TakesPaymentMixin):
     def amount_pending(self):
         return self.active_receipt.get('pending_total', 0)
 
+    @property
+    def is_paid(self):
+        return self.active_receipt.get('current_amount_owed', None) == 0
+
     @hybrid_property
     def amount_paid(self):
         return self.active_receipt.get('payment_total', 0)

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -320,6 +320,10 @@ class Group(MagModel, TakesPaymentMixin):
         return self.default_cost + self.amount_extra
 
     @property
+    def is_paid(self):
+        return self.active_receipt.get('current_amount_owed', None) == 0
+
+    @property
     def amount_unpaid(self):
         if self.registered:
             return max(0, ((self.total_cost * 100) - self.amount_paid - self.amount_pending) / 100)

--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -617,6 +617,7 @@ class Root:
                         cherrypy.session['attendee_account_id'] = new_or_existing_account.id
 
                 session.add(attendee)
+                receipt = session.get_receipt_by_model(attendee, create_if_none=True)
                 session.commit()
                 if c.AFTER_BADGE_PRICE_WAIVED:
                     message = c.AT_DOOR_WAIVED_MSG

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1414,12 +1414,12 @@ class Charge:
                 session.commit()
 
                 model = session.get_model_by_receipt(txn_receipt)
-                if isinstance(model, Attendee) and not model.amount_pending:
+                if isinstance(model, Attendee) and model.is_paid:
                     if model.badge_status == c.PENDING_STATUS:
                         model.badge_status = c.NEW_STATUS
                     if model.paid in [c.NOT_PAID, c.PENDING]:
                         model.paid = c.HAS_PAID
-                if isinstance(model, Group) and not model.amount_pending:
+                if isinstance(model, Group) and model.is_paid:
                     model.paid = c.HAS_PAID
                 session.add(model)
 


### PR DESCRIPTION
Includes the following:

- Fixes a bug where attendees with pending payments weren't marked as paid even when they had paid up
- Creates receipts for attendees when they first register at-door, so those receipts can be edited if needed
- Stops Stripe refund error messages