### PR TITLE
Add old normalization back into attendee accounts

### DIFF
--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -34,7 +34,7 @@ from uber.config import c, create_namespace_uuid
 from uber.errors import HTTPRedirect
 from uber.decorators import cost_property, department_id_adapter, presave_adjustment, suffix_property
 from uber.models.types import Choice, DefaultColumn as Column, MultiChoice
-from uber.utils import check_csrf, normalize_email, normalize_phone, DeptChecklistConf, report_critical_exception, \
+from uber.utils import check_csrf, normalize_email_legacy, normalize_phone, DeptChecklistConf, report_critical_exception, \
     valid_email, valid_password
 from uber.payments import ReceiptManager
 
@@ -970,7 +970,7 @@ class Session(SessionManager):
                 Attendee.watchlist_id == None).all()
 
         def get_attendee_account_by_email(self, email):
-            return self.query(AttendeeAccount).filter_by(email=normalize_email(email)).one()
+            return self.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(email)).one()
 
         def get_admin_account_by_email(self, email):
             from uber.utils import normalize_email_legacy
@@ -985,7 +985,7 @@ class Session(SessionManager):
                 last_name=last_name,
                 zip_code=zip_code
             ).filter(
-                Attendee.normalized_email == normalize_email(email),
+                Attendee.normalized_email == normalize_email_legacy(email),
                 Attendee.is_valid == True
             ).limit(10).all()
 
@@ -1061,10 +1061,7 @@ class Session(SessionManager):
             from uber.models import Attendee, AttendeeAccount
             from uber.utils import normalize_email_legacy
 
-            if email:
-                normalized_email = uber.utils.normalize_email(email)
-
-            new_account = AttendeeAccount(email=normalized_email, hashed=bcrypt.hashpw(password, bcrypt.gensalt()) if password else '')
+            new_account = AttendeeAccount(normalized_email=normalize_email_legacy(email), hashed=bcrypt.hashpw(password, bcrypt.gensalt()) if password else '')
             self.add(new_account)
 
             return new_account
@@ -1076,7 +1073,7 @@ class Session(SessionManager):
                 account.attendees.append(attendee)
 
         def match_attendee_to_account(self, attendee):
-            existing_account = self.query(AttendeeAccount).filter_by(email=normalize_email(attendee.email)).first()
+            existing_account = self.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(attendee.email)).first()
             if existing_account:
                 self.add_attendee_to_account(attendee, existing_account)
 
@@ -1622,6 +1619,7 @@ class Session(SessionManager):
             attendees = self.query(Attendee) \
                             .outerjoin(Attendee.group) \
                             .outerjoin(Attendee.promo_code) \
+                            .outerjoin(Attendee.managers) \
                             .outerjoin(aliased_pcg, PromoCode.group) \
                             .options(
                                 joinedload(Attendee.group),
@@ -1700,9 +1698,11 @@ class Session(SessionManager):
                         target, term, search_term, op = self.parse_attr_search_terms(search_text)
 
                         if target == 'email':
-                            attr_search_filter = Attendee.normalized_email.icontains(normalize_email(search_term))
+                            attr_search_filter = Attendee.normalized_email.contains(normalize_email_legacy(search_term))
+                        elif target == 'account_email':
+                            attr_search_filter = AttendeeAccount.normalized_email.contains(normalize_email_legacy(search_term))
                         elif target == 'group':
-                            attr_search_filter = Group.name.icontains(search_term.strip())
+                            attr_search_filter = Group.normalized_name.contains(search_term.strip().lower())
                         elif target == 'has_ribbon':
                             attr_search_filter = Attendee.ribbon == Attendee.ribbon.type.convert_if_labels(search_term.title())
                         elif target in Attendee.searchable_bools:

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -175,6 +175,14 @@ class Group(MagModel, TakesPaymentMixin):
         badges.
         """
         return [a for a in self.attendees if a.is_unassigned and a.paid == c.PAID_BY_GROUP]
+    
+    @hybrid_property
+    def normalized_name(self):
+        return self.name.strip().lower()
+
+    @normalized_name.expression
+    def normalized_name(cls):
+        return func.lower(func.trim(cls.name))
 
     @hybrid_property
     def is_valid(self):

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -101,12 +101,15 @@ def check_account(session, email, password, confirm_password, skip_if_logged_in=
 
     if email and valid_email(email):
         return valid_email(email)
+    
+    super_normalized_old_email = normalize_email_legacy(normalize_email(old_email))
 
-    existing_account = session.query(AttendeeAccount).filter_by(email=normalize_email(email)).first()
-    if existing_account and (old_email and existing_account.email != normalize_email(old_email)
-            or logged_in_account and logged_in_account.email != existing_account.email
+    existing_account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(email)).first()
+    if existing_account and (old_email and normalize_email_legacy(normalize_email(existing_account.email)) != super_normalized_old_email
             or not old_email and not logged_in_account):
         return "There's already an account with that email address."
+    elif logged_in_account and logged_in_account.normalized_email != existing_account.normalized_email:
+        return "You cannot reset someone's password while logged in as someone else."
     
     if update_password:
         if password and password != confirm_password:
@@ -117,7 +120,7 @@ def check_account(session, email, password, confirm_password, skip_if_logged_in=
 def set_up_new_account(session, attendee, email=None):
     email = email or attendee.email
     token = genpasswd(short=True)
-    account = session.query(AttendeeAccount).filter_by(email=normalize_email(email)).first()
+    account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(email)).first()
     if account:
         if account.password_reset:
             session.delete(account.password_reset)
@@ -1378,7 +1381,7 @@ class Root:
     @ajax
     def create_account(self, session, **params):
         email = params.get('account_email') # This email has already been validated
-        account = session.query(AttendeeAccount).filter_by(email=normalize_email(email)).first()
+        account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(email)).first()
         if account:
             return {'success': False, 'message': "You already have an account. Please use the 'forgot your password' link. \
                     Keep in mind your account may be from a prior year."}
@@ -1430,7 +1433,7 @@ class Root:
             message = "Something went wrong. Please try again."
         if not attendee.email:
             message = "This attendee needs an email address to set up a new account."
-        if session.current_attendee_account() and normalize_email(attendee.email) == session.current_attendee_account().email:
+        if session.current_attendee_account() and normalize_email_legacy(attendee.email) == session.current_attendee_account().normalized_email:
             message = "You cannot grant an account to someone with the same email address as your account."
         if not message:
             set_up_new_account(session, attendee)
@@ -1803,7 +1806,7 @@ class Root:
     def reset_password(self, session, **params):
         if 'account_email' in params:
             account_email = params['account_email']
-            account = session.query(AttendeeAccount).filter_by(email=normalize_email(account_email)).first()
+            account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(account_email)).first()
             if 'admin_url' in params:
                 success_url = "../{}message=Password reset email sent.".format(params['admin_url'])
             else:
@@ -1835,7 +1838,7 @@ class Root:
         if 'id' in params:
             account = session.attendee_account(params['id'])
         else:
-            account = session.query(AttendeeAccount).filter_by(email=normalize_email(account_email)).first()
+            account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(account_email)).first()
         if not account or not account.password_reset:
             message = 'Invalid link. This link may have already been used or replaced.'
         elif account.password_reset.is_expired:
@@ -1852,7 +1855,7 @@ class Root:
                                     params.get('confirm_password'), False, True, account.email)
 
             if not message:
-                account.email = account_email
+                account.email = normalize_email(account_email)
                 account.hashed = bcrypt.hashpw(account_password, bcrypt.gensalt())
                 session.delete(account.password_reset)
                 for attendee in account.attendees:

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -65,7 +65,7 @@ def comped_receipt_item(item):
 def assign_account_by_email(session, attendee, account_email):
     from uber.site_sections.preregistration import set_up_new_account
 
-    account = session.query(AttendeeAccount).filter_by(email=normalize_email(account_email)).first()
+    account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(account_email)).first()
     if not account:
         if c.ONE_MANAGER_PER_BADGE and attendee.managers:
             # It's too confusing for an admin to move someone to a new account and still see them on their old account
@@ -513,7 +513,7 @@ class Root:
         if not show_all:
             attendees = attendees.filter_by(is_valid=True, is_unassigned=False)
         if email_contains:
-            attendees = attendees.filter(Attendee.normalized_email.contains(normalize_email(email_contains)))
+            attendees = attendees.filter(Attendee.normalized_email.contains(normalize_email_legacy(email_contains)))
         
         new_account = 0
         assigned = 0
@@ -584,10 +584,10 @@ class Root:
 
         new_email = params.get('new_account_email', '')
         if cherrypy.request.method == 'POST' and new_email:
-            if normalize_email(new_email) == normalize_email(account.email):
+            if normalize_email(normalize_email_legacy(new_email)) == normalize_email(account.normalized_email):
                 message = "That is already the email address for this account!"
             else:
-                existing_account = session.query(AttendeeAccount).filter_by(email=normalize_email(new_email)).first()
+                existing_account = session.query(AttendeeAccount).filter_by(normalized_email=normalize_email_legacy(new_email)).first()
                 if existing_account:
                     message = "That account already exists. You can instead reassign this account's attendees."
                 else:

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1324,7 +1324,7 @@ class TaskUtils:
                 except Exception as ex:
                     import_job.errors += "; {}".format("; ".join(str(ex))) if import_job.errors else "; ".join(str(ex))
 
-                account = session.query(AttendeeAccount).filter(AttendeeAccount.email == normalize_email(account_to_import['email'])).first()
+                account = session.query(AttendeeAccount).filter(AttendeeAccount.normalized_email == normalize_email_legacy(account_to_import['email'])).first()
                 if not account:
                     del account_to_import['id']
                     account = AttendeeAccount().apply(account_to_import, restricted=False)
@@ -1416,7 +1416,7 @@ class TaskUtils:
                     import_job.completed = datetime.now()
                     return
 
-            account = session.query(AttendeeAccount).filter(AttendeeAccount.email == normalize_email(account_to_import['email'])).first()
+            account = session.query(AttendeeAccount).filter(AttendeeAccount.normalized_email == normalize_email_legacy(account_to_import['email'])).first()
             if not account:
                 del account_to_import['id']
                 account = AttendeeAccount().apply(account_to_import, restricted=False)
@@ -1546,7 +1546,7 @@ class TaskUtils:
                     except Exception as ex:
                         import_job.errors += "; {}".format("; ".join(str(ex))) if import_job.errors else "; ".join(str(ex))
 
-                    account = session.query(AttendeeAccount).filter(AttendeeAccount.email == normalize_email(account_to_import['email'])).first()
+                    account = session.query(AttendeeAccount).filter(AttendeeAccount.normalized_email == normalize_email_legacy(account_to_import['email'])).first()
                     if not account:
                         del account_to_import['id']
                         account = AttendeeAccount().apply(account_to_import, restricted=False)


### PR DESCRIPTION
Whatever I did before caused way too many problems, so now we are using the old normalized emails for attendee accounts again. This should hopefully stop creating multiple accounts with different cases.