### PR TITLE
Count # of years imported accounts are empty

### DIFF
--- a/alembic/versions/94aa84890142_add_unused_years_count_to_attendee_.py
+++ b/alembic/versions/94aa84890142_add_unused_years_count_to_attendee_.py
@@ -1,0 +1,59 @@
+"""Add unused years count to attendee accounts
+
+Revision ID: 94aa84890142
+Revises: 0a7104b8792a
+Create Date: 2025-04-03 12:55:41.305235
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = '94aa84890142'
+down_revision = '0a7104b8792a'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except Exception:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+# ===========================================================================
+# HOWTO: Handle alter statements in SQLite
+#
+# def upgrade():
+#     if is_sqlite:
+#         with op.batch_alter_table('table_name', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+#             batch_op.alter_column('column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#     else:
+#         op.alter_column('table_name', 'column_name', type_=sa.Unicode(), server_default='', nullable=False)
+#
+# ===========================================================================
+
+
+def upgrade():
+    op.add_column('attendee_account', sa.Column('unused_years', sa.Integer(), server_default='0', nullable=False))
+
+
+def downgrade():
+    op.drop_column('attendee_account', 'unused_years')

--- a/uber/models/__init__.py
+++ b/uber/models/__init__.py
@@ -1163,6 +1163,7 @@ class Session(SessionManager):
             if c.ONE_MANAGER_PER_BADGE and attendee.managers and not unclaimed_account:
                 attendee.managers.clear()
             if attendee not in account.attendees:
+                account.unused_years = 0
                 account.attendees.append(attendee)
 
         def match_attendee_to_account(self, attendee):

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -2348,6 +2348,7 @@ class AttendeeAccount(MagModel):
         cascade='save-update,merge,refresh-expire,expunge',
         secondary='attendee_attendee_account')
     imported = Column(Boolean, default=False)
+    unused_years = Column(Integer, default=0)
 
     email_model_name = 'account'
 

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -477,6 +477,15 @@ def create_badge_pickup_groups():
             session.commit()
 
 
+@celery.schedule(timedelta(days=60))
+def sunset_empty_accounts():
+    with Session() as session:
+        empty_accounts = session.query(AttendeeAccount).filter(AttendeeAccount.unused_years > 2)
+        for account in empty_accounts:
+            session.delete(account)
+        session.commit()
+
+
 @celery.task
 def import_attendee_accounts(accounts, admin_id, admin_name, target_server, api_token):
     already_queued = 0

--- a/uber/utils.py
+++ b/uber/utils.py
@@ -1811,6 +1811,7 @@ class TaskUtils:
                     account.email = normalize_email(account.email)
                     account.imported = True
                     session.add(account)
+                account.unused_years = 0
                 attendee.managers.append(account)
 
             from sqlalchemy.exc import IntegrityError
@@ -1948,6 +1949,15 @@ class TaskUtils:
                     session.rollback()
                 session.commit()
 
+            # This is the only import that may import 'empty' accounts
+            # We sunset accounts that have been empty for 3 years in another task
+            if not account.attendees:
+                account.unused_years += 1
+            else:
+                account.unused_years = 0
+            session.add(account)
+            session.commit()
+
     @staticmethod
     def group_import(import_job):
         # Import groups, then their attendees, then those attendee's accounts
@@ -2033,6 +2043,7 @@ class TaskUtils:
                         account.email = normalize_email(account.email)
                         account.imported = True
                         session.add(account)
+                    account.unused_years = 0
                     new_attendee.managers.append(account)
 
                 session.add(new_attendee)


### PR DESCRIPTION
This won't do anything for us immediately, but by keeping track of the number of years an account remains empty we can sunset accounts that haven't been associated with a badge in 2+ years.