### PR TITLE
Add group name setter

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -1421,7 +1421,12 @@ class Attendee(MagModel, TakesPaymentMixin):
     @group_name.expression
     def group_name(cls):
         return select([Group.name]).where(Group.id == cls.group_id).label('group_name')
-    
+
+    @group_name.setter
+    def group_name(self, value):
+        if self.group:
+            self.group.name = value
+
     @property
     def group_leader_account(self):
         if self.group and self.group.leader and self.group.leader.managers:


### PR DESCRIPTION
For the fix for SEI_SD-1726, we need to be able to set the group name via the attendee. Adding a setter to the event plugin doesn't actually work, so it needs to be done here.

![image](https://github.com/user-attachments/assets/c75d0644-bdd7-4eea-87d1-69006e9de741)
