### PR TITLE
Let groups add existing badges

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -209,7 +209,7 @@ class Attendee(MagModel, TakesPaymentMixin):
         'BadgePickupGroup', backref=backref('attendees', order_by='Attendee.full_name'), foreign_keys=badge_pickup_group_id,
         cascade='save-update,merge,refresh-expire,expunge', single_parent=True)
 
-    creator_id = Column(UUID, ForeignKey('attendee.id'), nullable=True)
+    creator_id = Column(UUID, ForeignKey('attendee.id', ondelete='set null'), nullable=True)
     creator = relationship(
         'Attendee',
         foreign_keys='Attendee.creator_id',

--- a/uber/models/group.py
+++ b/uber/models/group.py
@@ -421,6 +421,14 @@ class Group(MagModel, TakesPaymentMixin):
         return self.dealer_max_badges - self.badges
 
     @property
+    def can_add_existing_badges(self):
+        """
+        Enables the "Add by confirmation number" button on the group members page,
+        as long as the group is paid up and has no T&C to sign.
+        """
+        return False
+
+    @property
     def hours_since_registered(self):
         if not self.registered:
             return 0

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}{% set admin_area=True %}
-{% import "forms/group.html" as group_fields with context %}
 {% import 'forms/macros.html' as form_macros with context %}
 {% block title %}Group Form{% endblock %}
 {% block content %}

--- a/uber/templates/preregistration/dealer_group_members.html
+++ b/uber/templates/preregistration/dealer_group_members.html
@@ -1,0 +1,85 @@
+{% block status %}
+{% if group.status in c.DEALER_ACCEPTED_STATUSES %}
+    <div class="alert alert-success pb-0" role="alert">
+    <p>Congratulations, your {{ c.DEALER_APP_TERM }} has been <strong>approved</strong>!</p>
+    {% if group.cost %}
+      <p>Here is your group's cost breakdown:</p>
+      <ul>
+        {% if group.auto_recalc %}
+          {% if group.tables %}
+            <li>{{ group.default_table_cost|format_currency }} for {% if group.tables_repr %}a {{ group.tables_repr }}{% else %}{{ group.tables }} table{{ group.tables|pluralize }}{% endif %}</li>
+          {% endif %}
+          {% if group.badges_purchased %}
+            <li>{{ group.default_badge_cost|format_currency }} for {{ group.badges_purchased }} badge{{ group.badges_purchased|pluralize }}</li>
+          {% endif %}
+        {% else %}
+          <li>{{ group.cost|format_currency }} total cost</li>
+        {% endif %}
+        <li>{{ (group.amount_paid / 100)|format_currency or '$0' }} paid{% if group.amount_unpaid %} so far{% endif %}</li>
+        {% if group.amount_unpaid %}
+          <li>{{ group.amount_unpaid|format_currency }} unpaid</li>
+        {% endif %}
+        </ul>
+        {% if c.SIGNNOW_DEALER_FOLDER_ID and not c.SIGNNOW_DEALER_TEMPLATE_ID %}
+        <p>
+          Your next step will be to sign our terms and conditions for vending at {{ c.EVENT_NAME }}, but we're still preparing them!
+          Sit tight and we'll email them to you when they're ready, after which you can pay for your membership on this page.
+        </p>
+        {% elif not c.SIGNNOW_DEALER_FOLDER_ID or signnow_document and signnow_document.signed %}
+          {% if group.amount_unpaid %}
+            {% if c.AT_THE_CON and c.SPIN_TERMINAL_AUTH_KEY %}
+              <p>Please see the help desk at Registration to complete your payment.</p>
+            {% elif incomplete_txn %}
+              <p>You currently have an incomplete payment of {{ (incomplete_txn.amount / 100)|format_currency }}.</p>
+              <p>Click here to complete your payment: {{ stripe_form('finish_pending_group_payment', group, txn_id=incomplete_txn.id, stripe_button_id="complete_txn") }}</p>
+            {% else %}
+              <p>{{ stripe_form('process_group_payment', group) }}</p>
+            {% endif %}
+          {% endif %}
+        {% endif %}
+    {% endif %}
+    </div>
+{% elif group.status == c.CANCELLED %}
+    <div class="alert alert-info pb-0" role="alert">
+      <p>You have <strong>cancelled</strong> your {{ c.DEALER_APP_TERM }}. If this was a mistake, please contact us at
+      {{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}.</p>
+    </div>
+{% else %}
+    <div class="alert alert-{{ 'danger' if group.status == c.DECLINED else 'warning' }} pb-0" role="alert">
+      <p>Your {{ c.DEALER_APP_TERM }} {{ 'is' if group.status == c.UNAPPROVED else 'has been' }} <strong>{{ group.status_label }}</strong>.</p>
+      {% if group.status != c.UNAPPROVED and group.leader and group.leader.paid == c.PAID_BY_GROUP and c.DEALER_BADGE_PRICE == c.INITIAL_ATTENDEE %}
+        <p>If you'd like to attend the event regardless of your application status, you can purchase your badge now by clicking the button below. Your {{ c.DEALER_APP_TERM }} will remain {{ group.status_label }}.</p>
+        <p><a class="btn btn-success" href="../preregistration/purchase_dealer_badge?id={{ group.leader.id }}">Purchase Badge Now</a></p>
+      {% endif %}
+      {% if c.AFTER_MARKETPLACE_REG_START and c.BEFORE_MARKETPLACE_DEADLINE and group.leader %}
+        <p>If you would like, you may instead
+        <a href="../marketplace/index?attendee_id={{ group.leader.id }}" target="_blank">apply for a table in the Marketplace.</a></p>
+      {% endif %}
+    </div>
+{% endif %}
+{% endblock %}
+
+{% block terms %}
+{% if c.SIGNNOW_DEALER_TEMPLATE_ID and group.is_valid and group.status in c.DEALER_ACCEPTED_STATUSES %}
+  {% if signnow_document and signnow_document.signed %}
+  <span id="tc-link">
+    <a href="../preregistration/download_signnow_document?id={{ group.id }}" class="btn btn-info" role="button">
+      <i class="fa fa-download"></i> Terms and Conditions
+    </a>
+  </span>
+  <script type="text/javascript">
+    $(function() {
+      $('#tc-link').appendTo($("#dealer-actions"));
+    });
+  </script>
+  {% elif signnow_link %}
+  <div class="alert alert-danger pb-0" role="alert">
+    <p>We need you to sign our terms and conditions for vending at {{ c.EVENT_NAME }}.</p>
+    <p><a href="{{ signnow_link }}" class="btn btn-primary" target="_blank">
+      Review and Sign
+    </a></p>
+    <p>Make sure to click "Finish" at the bottom of the page to confirm your signature.</p>
+  </div>
+  {% endif %}
+{% endif %}
+{% endblock %}

--- a/uber/templates/preregistration/form.html
+++ b/uber/templates/preregistration/form.html
@@ -1,5 +1,4 @@
 {% extends "./preregistration/preregbase.html" %}
-{% import "forms/group.html" as group_fields with context %}
 {% import "forms/account.html" as account_fields with context %}
 {% import 'forms/macros.html' as form_macros with context %}
 {% if is_prereg_dealer %}

--- a/uber/templates/preregistration/group_add_members.html
+++ b/uber/templates/preregistration/group_add_members.html
@@ -1,0 +1,164 @@
+{% block members %}
+{% set add_badges_disabled = (c.SIGNNOW_DEALER_TEMPLATE_ID and (not signnow_document or not signnow_document.signed)) or (receipt and receipt.current_amount_owed) %}
+{% set member = group.is_dealer|yesno(c.DEALER_HELPER_TERM + ",group member") %}
+{% if group.is_valid and c.REMAINING_BADGES > 50 %}
+  <br/>
+  <p>
+  {% if group.is_dealer and group.min_badges_addable %}
+    You may purchase up to <strong>{{ group.dealer_badges_remaining }}</strong> additional {{ c.DEALER_HELPER_TERM }} badges.
+  {% elif group.is_dealer and group.status != c.SHARED %}
+    Please contact us at <strong>{{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}</strong> if you wish to purchase additional {{ c.DEALER_HELPER_TERM }} badges.
+  {% endif %}
+  </p>
+
+  {% if group.min_badges_addable %}
+    <div id="add" style="display:none;">
+      <form method="get" action="add_group_members">
+        <input type="hidden" name="id" value="{{ group.id }}" />
+        <input type="hidden" id="estimatedCost" name="estimated_cost" value="{{ group.new_badge_cost|default(0, true) }}" />
+        <div class="row g-sm-3">
+            <div class="col-auto">
+            {%- set min_badges = group.min_badges_addable -%}
+            Enter the number of {{ member }}s to add.
+            {% if min_badges > 1 -%}
+                {%- set hours_remaining = group.hours_remaining_in_grace_period -%}
+                {%- if hours_remaining > 0 -%}
+                {%- set min_badges = 1 -%}
+                You have {{ humanize_timedelta(hours=hours_remaining, granularity='minutes') }}
+                remaining to add individual {{ member }}s. After that you'll have to add at
+                least {{ group.min_badges_addable }} badges at a time.
+                {%- else -%}
+                You can't add fewer than {{ group.min_badges_addable }} badges to an existing group.
+                {%- endif -%}
+            {%- endif -%}
+            </div>
+        </div>
+        <div class="row">
+        <div class="col-auto">
+          <select class="form-select" id="newBadgeCount" name="count">
+          {%- if group.is_dealer -%}
+            {{ int_options(min_badges, group.dealer_badges_remaining) }}
+          {%- else -%}
+            {{ int_options(min_badges, 10) }}
+          {%- endif -%}
+          </select>
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-primary" id="newBadgeSubmit" type="submit">
+            Add {{ member|title }}s
+          </button>
+        </div>
+        </div>
+      </form>
+    </div>
+    {% if not c.AT_THE_CON and not c.AFTER_PREREG_TAKEDOWN or not c.SPIN_TERMINAL_AUTH_KEY %}
+        {% if c.SIGNNOW_DEALER_TEMPLATE_ID and (not signnow_document or not signnow_document.signed) %}
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="Please sign the terms and conditions at the top of the page before adding group members.">
+        {% elif receipt and receipt.current_amount_owed %}
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="Group must be paid for before new members can be added.">
+        {% endif %}
+            <button id="add-btn"{% if add_badges_disabled %} disabled{% endif %} class="btn btn-primary">Add more {{ member }}s</button>
+        {% if add_badges_disabled %}
+        </span>
+        {% endif %}
+
+        {% if not add_badges_disabled %}
+        <script type="text/javascript">
+            var newBadgePrice = {{ group.new_badge_cost|default(0, true) }};
+            var newBadgeSubmitText = 'Add {{ member|title }}(s)';
+            var updateBadgeEstimate = function() {
+                if(newBadgePrice == 0) { return; }
+                $('#estimatedCost').val(newBadgePrice * parseInt($('#newBadgeCount').val()));
+                $('#newBadgeSubmit').text(newBadgeSubmitText + " for $" + $('#estimatedCost').val());
+            }
+            $(function() {
+                $('#add-btn').click(function(e){
+                        $(e.target).hide();
+                        $("#add").show();
+                        updateBadgeEstimate();
+                    });
+                $('#newBadgeCount').change(function() {updateBadgeEstimate();});
+            });
+        </script>
+        {% endif %}
+    {% endif %}
+  {% endif %}
+{% endif %}
+{% if group.is_valid and not add_badges_disabled and group.can_add_existing_badges %}
+{% if group.is_valid and c.REMAINING_BADGES > 50 and group.min_badges_addable %}
+OR
+{% endif %}
+<button id="attach-btn"{% if add_badges_disabled %} disabled{% endif %} class="btn btn-primary mt-1">
+    Add {{ member }} by confirmation number
+</button>
+
+<div id="attach" style="display:none;" class="mt-1">
+    <div class="alert alert-dismissible" role="alert" id="attach-message-alert"><span></span><button type="button" class="btn-close" onClick="hideMessageBox('attach-message-alert')" aria-label="Close"></button></div>
+    <form method="post" id="find-group-member-form" action="find_group_member">
+        <input type="hidden" name="id" value="{{ group.id }}" />
+        {{ csrf_token() }}
+        <div class="row g-sm-3">
+            <div class="col-auto">
+                If one of your {{ member }}s has already bought a badge,
+                you can add them to your group by entering their registration confirmation number, first name, and last name below.
+                They can find their registration confirmation number in the confirmation email they received when they registered.
+            </div>
+        </div>
+        <div class="row g-sm-3">
+            <div class="col-12 col-sm-6">
+                <label class="form-text">Confirmation #</label>
+                <div>
+                  <input type="text" name="confirmation_id" class="form-control" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" required />
+                </div>
+            </div>
+            <div class="col-12 col-sm-3">
+                <label class="form-text">First Name</label>
+                <div class="mb-3">
+                  <input type="text" name="first_name" class="form-control" placeholder="First Name" required />
+                </div>
+            </div>
+            <div class="col-12 col-sm-3">
+                <label class="form-text">Last Name</label>
+                <div class="mb-3">
+                  <input type="text" name="last_name" class="form-control" placeholder="Last Name" required />
+                </div>
+            </div>
+        </div>
+        <div class="row g-sm-3">
+            <div class="col-12 col-sm-6">
+                <button type="submit" class="btn btn-primary">Search</button>
+            </div>
+        </div>
+</div>
+<script type="text/javascript">
+    var lookupGroupMember = function(event) {
+        event.preventDefault();
+        hideMessageBox('attach-message-alert');
+        $.ajax({
+            method: 'POST',
+            url: 'find_group_member',
+            dataType: 'json',
+            data: $(this).serialize(),
+            success: function (json) {
+            if (json.success) {
+                window.location.href = 'group_members?id={{ group.id }}&message=' + json.message;
+            } else {
+                showErrorMessage(json.message, 'attach-message-alert', false);
+            }
+            },
+            error: function () {
+                showErrorMessage('Unable to connect to server, please try again.', 'attach-message-alert', false);
+            }
+          });
+    }
+    $(function() {
+        hideMessageBox('attach-message-alert');
+        $('#attach-btn').click(function(e){
+            $(e.target).hide();
+            $("#attach").show();
+        });
+        $('#find-group-member-form').submit(lookupGroupMember);
+    });
+</script>
+{% endif %}
+{% endblock %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -1,61 +1,84 @@
 {% extends "./preregistration/preregbase.html" %}
 {% set page_ro = group.status not in c.DEALER_EDITABLE_STATUSES %}
-{% import "forms/group.html" as group_fields with context %}
 {% import 'forms/macros.html' as form_macros with context %}
 {% set title_text = "Group Members" %}
 {% block content %}
 <script type="text/javascript">
   var unsetMemberConfirm = function(event) {
     var formToSubmit = this;
-            event.preventDefault();
-            bootbox.confirm({
-                message: "This will permanently unassign this person's badge. They will receive an email about this. Are you sure?",
-                buttons: {
-                    confirm: {
-                        label: 'Unassign Badge',
-                        className: 'btn-danger'
-                    },
-                    cancel: {
-                        label: 'Nevermind',
-                        className: 'btn-outline-secondary'
-                    }
-                },
-                callback: function (result) {
-                    if(result) {
-                        formToSubmit.submit();
-                    }
-                }
-            });
+      event.preventDefault();
+      bootbox.confirm({
+          message: "This will permanently unassign this person's badge. They will receive an email about this. Are you sure?",
+          buttons: {
+              confirm: {
+                  label: 'Unassign Badge',
+                  className: 'btn-danger'
+              },
+              cancel: {
+                  label: 'Nevermind',
+                  className: 'btn-outline-secondary'
+              }
+          },
+          callback: function (result) {
+              if(result) {
+                  formToSubmit.submit();
+              }
+          }
+      });
+  }
+
+  var removeMemberConfirm = function(event) {
+    var formToSubmit = this;
+      event.preventDefault();
+      bootbox.confirm({
+          message: "This will remove this person from the group. Are you sure?",
+          buttons: {
+              confirm: {
+                  label: 'Remove Badge',
+                  className: 'btn-danger'
+              },
+              cancel: {
+                  label: 'Nevermind',
+                  className: 'btn-outline-secondary'
+              }
+          },
+          callback: function (result) {
+              if(result) {
+                  formToSubmit.submit();
+              }
+          }
+      });
   }
 
   var cancelConfirm = function(event) {
-            var formToSubmit = this;
-            event.preventDefault();
-            bootbox.confirm({
-                title: "Cancel Dealer Application?",
-                message: "This will permanently cancel your application. All registered badges in the group will be converted to individual badges. Are you sure?",
-                buttons: {
-                    confirm: {
-                        label: 'Yes, Cancel My Application',
-                        className: 'btn-danger'
-                    },
-                    cancel: {
-                        label: 'Nevermind',
-                        className: 'btn-outline-secondary'
-                    }
-                },
-                callback: function (result) {
-                    if(result) {
-                        formToSubmit.submit();
-                    }
-                }
-            });
+    var formToSubmit = this;
+    event.preventDefault();
+    bootbox.confirm({
+        title: "Cancel Dealer Application?",
+        message: "This will permanently cancel your application. All registered badges in the group will be converted to individual badges. Are you sure?",
+        buttons: {
+            confirm: {
+                label: 'Yes, Cancel My Application',
+                className: 'btn-danger'
+            },
+            cancel: {
+                label: 'Nevermind',
+                className: 'btn-outline-secondary'
+            }
+        },
+        callback: function (result) {
+            if(result) {
+                formToSubmit.submit();
+            }
         }
-    $().ready(function() {
-        $("form[action='unset_group_member']").submit(unsetMemberConfirm);
-
-        $("form[action='../preregistration/cancel_dealer']").submit(cancelConfirm);
     });
+  }
+  $().ready(function() {
+      $(".unset-group-member").submit(unsetMemberConfirm);
+      $(".remove-group-member").submit(removeMemberConfirm);
+
+      $("form[action='../preregistration/cancel_dealer']").submit(cancelConfirm);
+  });
 </script>
 
 <div class="card">
@@ -68,8 +91,7 @@
     {% include 'confirm_tabs.html' with context %}
     {% endif %}
     {% if group.is_dealer %}
-      {{ group_fields.status }}
-      {{ group_fields.signed_document }}
+      {% include 'preregistration/dealer_group_members.html' with context %}
       <h2 class="h5">"{{ group.name }}" Information</h2>
       {{ form_macros.form_validation('group-form', 'validate_dealer' if group.is_dealer else 'validate_group') }}
       <form method="post" action="group_members" role="form">
@@ -126,6 +148,7 @@
     isn't coming" button next to their entry on the list below to unset their badge, which may then be assigned to
     someone else. Upgraded badges may only be transferred directly between two people; please contact us at
     {{ c.REGDESK_EMAIL|email_only|email_to_link }} if you wish to transfer badges.
+    {% if group.can_add_existing_badges %}Badges purchased separately will be removed from the group without unsetting them.{% endif %}
 </div>
 {% elif group.attendees|length - group.floating|length != 1 %}
 <p>Because your {{ c.DEALER_APP_TERM }} is {{ group.status_label }}, you cannot add or assign {{ c.DEALER_HELPER_TERM }}s, but you can view your assigned {{ c.DEALER_HELPER_TERM }}s below.</p>
@@ -157,11 +180,20 @@
                 {% endif %}
             </td>
             <td>
-                {% if not attendee.cannot_abandon_badge_reason %}
-                  <form method="post" action="unset_group_member">
+                {% if not attendee.cannot_abandon_badge_reason and not attendee.admin_account and not attendee.dept_memberships_with_inherent_role
+                  or attendee.paid != c.PAID_BY_GROUP %}
+                  <form method="post"
+                        class="{% if attendee.paid == c.PAID_BY_GROUP %}unset-group-member{% else %}remove-group-member{% endif %}"
+                        action="unset_group_member">
                     {{ csrf_token() }}
                     <input type="hidden" name="id" value="{{ attendee.id }}" />
-                    <button class="btn btn-sm btn-warning" type="submit" style="margin: 5px 0;">This person isn't coming</button>
+                    <button class="btn btn-sm btn-warning" type="submit" style="margin: 5px 0;">
+                      {% if attendee.paid == c.PAID_BY_GROUP %}
+                      This person isn't coming
+                      {% else %}
+                      Remove from group
+                      {% endif %}
+                    </button>
                   </form>
                 {% elif attendee.is_transferable %}
                   <form method="get" action="transfer_badge">
@@ -181,82 +213,7 @@
 {% endfor %}
 </table>
 
-{% if group.status not in [c.CANCELLED, c.DECLINED] and c.REMAINING_BADGES > 50 %}
-        <br/>{% if group.is_dealer and group.min_badges_addable %}
-        You may purchase up to <strong>{{ group.dealer_badges_remaining }}</strong> additional {{ c.DEALER_HELPER_TERM }} badges.<br/><br/>
-        {% elif group.is_dealer and group.status != c.SHARED %}
-        Please contact us at <strong>{{ c.MARKETPLACE_EMAIL|email_only|email_to_link }}</strong> if you wish to purchase additional {{ c.DEALER_HELPER_TERM }} badges.
-        {% endif %}
-
-{% if group.min_badges_addable %}
-    <div id="add" style="display:none">
-      <form method="get" action="add_group_members">
-        <input type="hidden" name="id" value="{{ group.id }}" />
-        <input type="hidden" id="estimatedCost" name="estimated_cost" value="{{ group.new_badge_cost|default(0, true) }}" />
-        <div class="row g-sm-3">
-          {%- set min_badges = group.min_badges_addable -%}
-          {%- set members = group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") -%}
-          Enter the number of {{ members }} to add.
-          {% if min_badges > 1 -%}
-            {%- set hours_remaining = group.hours_remaining_in_grace_period -%}
-            {%- if hours_remaining > 0 -%}
-              {%- set min_badges = 1 -%}
-              You have {{ humanize_timedelta(hours=hours_remaining, granularity='minutes') }}
-              remaining to add individual {{ members }}. After that you'll have to add at
-              least {{ group.min_badges_addable }} badges at a time.
-            {%- else -%}
-              You can't add fewer than {{ group.min_badges_addable }} badges to an existing group.
-            {%- endif -%}
-          {%- endif -%}
-        </div>
-        <div class="row">
-        <div class="col-auto">
-          <select class="form-select" id="newBadgeCount" name="count">
-          {%- if group.is_dealer -%}
-            {{ int_options(min_badges, group.dealer_badges_remaining) }}
-          {%- else -%}
-            {{ int_options(min_badges, 10) }}
-          {%- endif -%}
-          </select>
-        </div>
-        <div class="col-auto">
-          <button class="btn btn-primary" id="newBadgeSubmit" type="submit">
-            Add {{ members|title }}
-          </button>
-        </div>
-        </div>
-      </form>
-    </div>
-
-    {% if not c.AT_THE_CON and not c.AFTER_PREREG_TAKEDOWN or not c.SPIN_TERMINAL_AUTH_KEY %}
-    <script type="text/javascript">
-        {% if receipt and receipt.current_amount_owed %}
-            $(function(){
-                $('<div class="disabled" title="Group must be paid for before new members can be added.">' +
-                    '<button disabled class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}</button>' +
-                  '</div>').insertAfter($("#add"));
-            });
-        {% else %}
-        var newBadgePrice = {{ group.new_badge_cost|default(0, true) }};
-        var newBadgeSubmitText = 'Add {{ members|title }}(s)';
-        var updateBadgeEstimate = function() {
-          if(newBadgePrice == 0) { return; }
-          $('#estimatedCost').val(newBadgePrice * parseInt($('#newBadgeCount').val()));
-          $('#newBadgeSubmit').text(newBadgeSubmitText + " for $" + $('#estimatedCost').val());
-        }
-            $(function(){
-                $('<button class="btn btn-primary">Click here to add more {{ group.is_dealer|yesno(c.DEALER_HELPER_TERM + "s,group members") }}</button>').click(function(e){
-                        $(e.target).hide();
-                        $("#add").show();
-                        updateBadgeEstimate();
-                    }).insertAfter($("#add"));
-                $('#newBadgeCount').change(function() {updateBadgeEstimate();});
-            });
-        {% endif %}
-    </script>
-    {% endif %}
-{% endif %}
-{% endif %}
+{% include 'preregistration/group_add_members.html' with context %}
 </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Gives group leaders the ability to add existing badges by entering their ID, first name, and last name. This is disabled by default via the "can_add_existing_badges" property -- we're using a DB property rather than a config option as it's likely any event that uses it will want to enable it only for specific kinds of groups.

Also fixes a fairly serious bug where a badge that was not paid for by a group could be unset and then reassigned... yikes. Similarly, badges now can't be unset if they have an admin account or are a department head.

Also also, breaks up the group members template a bit more -- this was originally to allow override via plugin, but I ended up putting the functionality in the main repo since it relies on page handlers.