### PR TITLE
Fix dealer refunds being skipped

### DIFF
--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -745,7 +745,8 @@ class Root:
             session.refresh(receipt)
 
             for txn in receipt.refundable_txns:
-                if txn.department == getattr(model, 'department', c.OTHER_RECEIPT_ITEM):
+                if txn.department == getattr(model, 'department', c.OTHER_RECEIPT_ITEM
+                                             ) or getattr(model, 'is_dealer', None) and txn.department == c.DEALER_RECEIPT_ITEM:
                     refund_amount = txn.amount_left
                     if exclude_fees:
                         processing_fees = txn.calc_processing_fee(refund_amount)


### PR DESCRIPTION
When I implemented per-category refunds I failed to account for the fact that the Group model's department changes based on if the group is a dealer or not. Checking the category when refunding may not be the best approach to begin with, but for this year we'll just do a quick fix.