### PR TITLE
Support preselling one-day badges

### DIFF
--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -934,6 +934,9 @@ class Attendee(MagModel, TakesPaymentMixin):
     def available_badge_type_opts(self):
         if self.is_new or self.badge_type == c.ATTENDEE_BADGE and self.is_unpaid:
             return c.FORMATTED_BADGE_TYPES
+        
+        if self.badge_type == c.ONE_DAY_BADGE or self.is_presold_oneday:
+            return c.FORMATTED_BADGE_TYPES
 
         badge_type_price = c.BADGE_TYPE_PRICES[self.badge_type] if self.badge_type in c.BADGE_TYPE_PRICES else 0
 

--- a/uber/templates/forms/macros.html
+++ b/uber/templates/forms/macros.html
@@ -213,7 +213,7 @@
 {% if is_preview %}
 <strong>The following badges are currently available:</strong>
 {% else %}
-<fieldset>
+<fieldset id="{{ target_field.id }}-select">
   <legend class="mt-3 mb-0 form-text">
     {{ kwargs['label'] if 'label' in kwargs else target_field.label.text }}{% if label_required %}<span class="required-indicator text-danger"> *</span>{% endif %}
   </legend>


### PR DESCRIPTION
Fixes a few things needed for MFF to presell one-day badges by adding a selector to the card options for easy access via JS and avoiding treating a one-day badge as equal to an attendee badge in available_badge_type_opts.