### PR TITLE
Add support for dealer file uploads

### DIFF
--- a/uber/forms/__init__.py
+++ b/uber/forms/__init__.py
@@ -3,7 +3,7 @@ import six
 import cherrypy
 
 from collections import defaultdict, OrderedDict
-from wtforms import Form, StringField, SelectField, SelectMultipleField, IntegerField, BooleanField, validators, Label
+from wtforms import Form, StringField, SelectField, SelectMultipleField, FileField, IntegerField, BooleanField, validators, Label
 import wtforms.widgets.core as wtforms_widgets
 from wtforms.validators import ValidationError
 from pockets.autolog import log
@@ -282,6 +282,8 @@ class MagForm(Form):
                 return 'hidden'
             elif isinstance(widget, Ranking):
                 return 'ranking'
+            elif isinstance(widget, wtforms_widgets.FileInput):
+                return 'file'
             else:
                 return 'text'
 

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -1243,8 +1243,6 @@ class Root:
             form_list = ['GroupInfo']
 
         forms = load_forms(params, group, form_list)
-        for form in forms.values():
-            form.populate_obj(group)
 
         signnow_document = None
         signnow_link = ''
@@ -1273,6 +1271,8 @@ class Root:
                 session.commit()
 
         if cherrypy.request.method == 'POST':
+            for form in forms.values():
+                form.populate_obj(group)
             session.commit()
             if group.is_dealer:
                 send_email.delay(

--- a/uber/templates/forms/macros.html
+++ b/uber/templates/forms/macros.html
@@ -115,6 +115,18 @@
     {{ form_input_extras(field, help_text, admin_text, extra_field) }}
   </div>
   {% endif %}
+{% elif type == 'file' %}
+<div class="form-text">{{ form_label(field, label_text=label_text, required=label_required) }}</div>
+<div{% if not no_margin %} class="mb-3"{% endif %}>
+  {% if field.data %}{{ field.data }}<br/>{% endif %}
+  {{ field(**custom_kwargs) }}
+  {% if extra_field %}
+  <div class="col col-6 mt-1">
+    {{ extra_field }}
+  </div>
+  {% endif %}
+  {{ form_input_extras(field, help_text, admin_text) }}
+</div>
 {% else %}
 <div class="form-floating{% if not no_margin %} mb-3{% endif %}">
     {{ field(class="form-control", **custom_kwargs) }}
@@ -366,77 +378,84 @@
   serverValidationPassed = false;
   
   var runServerValidations_{{ form_id|replace('-','_') }} = function($form, submit_button_name, submit_button_val) {
+    var form_data = new FormData($('#{{ form_id }}')[0]);
     var form_list = {{ form_list|safe }}.join(',')
-    var submit_param = ''
     if (form_list != '') {
-        form_list = '&form_list=' + form_list
+      form_data.set('form_list', form_list);
     }
     if (submit_button_name != '') {
-      submit_param = '&' + submit_button_name + '=' + submit_button_val;
+      form_data.set(submit_button_name, submit_button_val);
     }
-    $.post("{{ page_handler }}", $form.serialize() + form_list + submit_param, function (response) {
-      $("#form-validations-{{ form_id }}").hide().removeClass().addClass("alert").children('span').html("");
-      $(".is-invalid").each(function() {
-        var field_id = $(this).attr('id');
-        $(this).removeClass('is-invalid');
-        $("#" + field_id + "-validation").hide();
-      });
-      if (response.warning) {
-        let buttonText = response.button_text ? response.button_text : 'I understand, please continue!';
-        $("#form-validations-{{ form_id }}").addClass("alert-warning").children('span').html(
-          response.warning +
-          "<button form='{{ form_id }}' class='btn btn-primary' name='"+ submit_button_name +"'>" +
-            buttonText +
-          "</button>"
-          );
-        $("#form-validations-{{ form_id }}").show();
-        $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
-        serverValidationPassed = true;
-      } else if (response.error) {
-          if (typeof response.error === "string") {
-            $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(response.error);
-          } else {
-            $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(
-              "Please correct the following errors:" +
-              "<ul></ul>"
+    $.ajax({
+      method: 'POST',
+      url: "{{ page_handler }}",
+      data: form_data,
+      processData: false,
+      contentType: false,
+      success: function (response) {
+        $("#form-validations-{{ form_id }}").hide().removeClass().addClass("alert").children('span').html("");
+        $(".is-invalid").each(function() {
+          var field_id = $(this).attr('id');
+          $(this).removeClass('is-invalid');
+          $("#" + field_id + "-validation").hide();
+        });
+        if (response.warning) {
+          let buttonText = response.button_text ? response.button_text : 'I understand, please continue!';
+          $("#form-validations-{{ form_id }}").addClass("alert-warning").children('span').html(
+            response.warning +
+            "<button form='{{ form_id }}' class='btn btn-primary' name='"+ submit_button_name +"'>" +
+              buttonText +
+            "</button>"
             );
-            $.each(response.error, function(key, val) {
-              val = val.join(" ");
-              if ($("#" + key).length != 0 && $("#" + key).attr('type') != 'checkbox') {
-                var field_label = $("label[for='" + key + "'] .form-label").text();
-                if (field_label == '') { field_label = $("#" + key).children("legend").children(".form-label").text(); }
-                if (field_label == '') {
-                  $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
+          $("#form-validations-{{ form_id }}").show();
+          $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
+          serverValidationPassed = true;
+        } else if (response.error) {
+            if (typeof response.error === "string") {
+              $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(response.error);
+            } else {
+              $("#form-validations-{{ form_id }}").addClass("alert-danger").children('span').html(
+                "Please correct the following errors:" +
+                "<ul></ul>"
+              );
+              $.each(response.error, function(key, val) {
+                val = val.join(" ");
+                if ($("#" + key).length != 0 && $("#" + key).attr('type') != 'checkbox') {
+                  var field_label = $("label[for='" + key + "'] .form-label").text();
+                  if (field_label == '') { field_label = $("#" + key).children("legend").children(".form-label").text(); }
+                  if (field_label == '') {
+                    $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
+                  } else {
+                    $("#form-validations-{{ form_id }}").find("ul").append("<li>" + field_label + ": " + val + "</li>");
+                    $("#" + key).addClass("is-invalid");
+                  }
                 } else {
-                  $("#form-validations-{{ form_id }}").find("ul").append("<li>" + field_label + ": " + val + "</li>");
-                  $("#" + key).addClass("is-invalid");
+                  $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
                 }
-              } else {
-                $("#form-validations-{{ form_id }}").find("ul").append("<li>" + val + "</li>");
-              }
 
-              if ($("#" + key + "-validation").length != 0)
-              {
-                $("#" + key + "-validation").html(val).show();
-              }
-            });
-          }
-        $("#form-validations-{{ form_id }}").show();
-        $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
-      } else {
-        serverValidationPassed = true;
-        {% if callback %}
-          {{ callback|safe }};
-        {% else %}
-        if (submit_button_name != '') {
-          console.log($("#{{ form_id }}").find($("[name=" + submit_button_name + "]")))
-          $("#{{ form_id }}").find($("[name=" + submit_button_name + "]")).click();
+                if ($("#" + key + "-validation").length != 0)
+                {
+                  $("#" + key + "-validation").html(val).show();
+                }
+              });
+            }
+          $("#form-validations-{{ form_id }}").show();
+          $('html, body').animate({scrollTop: $("#form-validations-{{ form_id }}").offset().top}, 50);
         } else {
-          $("#{{ form_id }}").submit();
+          serverValidationPassed = true;
+          {% if callback %}
+            {{ callback|safe }};
+          {% else %}
+          if (submit_button_name != '') {
+            console.log($("#{{ form_id }}").find($("[name=" + submit_button_name + "]")))
+            $("#{{ form_id }}").find($("[name=" + submit_button_name + "]")).click();
+          } else {
+            $("#{{ form_id }}").submit();
+          }
+          {% endif %}
         }
-        {% endif %}
       }
-    }, 'json');
+    });
   };
   
 

--- a/uber/templates/group_admin/form.html
+++ b/uber/templates/group_admin/form.html
@@ -82,7 +82,7 @@
     <h3>New {{ c.DEALER_TERM|title if group.is_dealer else "Group" }} Info</h3>
   {% endif %}
   {{ form_macros.form_validation('group-form', 'validate_group') }}
-  <form novalidate method="post" id="group-form" action="form">
+  <form novalidate method="post" id="group-form" action="form" enctype="multipart/form-data">
     {{ csrf_token() }}
     <input type="hidden" name="id" value="{{ group.db_id }}" />
     <input type="hidden" name="new_dealer" value="{{ new_dealer or '' }}" />

--- a/uber/templates/preregistration/dealer_registration.html
+++ b/uber/templates/preregistration/dealer_registration.html
@@ -11,7 +11,7 @@
   {{ form_macros.form_validation('dealer-form', 'validate_dealer') }}
 
 {#- The action is set to "post_form" or "post_dealer" in order to bypass the NGINX cache. -#}
-<form novalidate method="post" id="dealer-form" action="post_dealer" class="form-horizontal" role="form">
+<form novalidate method="post" id="dealer-form" action="post_dealer" class="form-horizontal" role="form" enctype="multipart/form-data">
 {% if edit_id %}
     <input type="hidden" name="edit_id" value="{{ edit_id }}" />
 {% endif %}

--- a/uber/templates/preregistration/group_members.html
+++ b/uber/templates/preregistration/group_members.html
@@ -94,7 +94,7 @@
       {% include 'preregistration/dealer_group_members.html' with context %}
       <h2 class="h5">"{{ group.name }}" Information</h2>
       {{ form_macros.form_validation('group-form', 'validate_dealer' if group.is_dealer else 'validate_group') }}
-      <form novalidate method="post" id="group-form" action="group_members" role="form">
+      <form novalidate method="post" id="group-form" action="group_members" role="form" enctype="multipart/form-data">
         {{ csrf_token() }}
         <input type="hidden" name="id" value="{{ group.id }}" />
         {% if forms and 'group_info' in forms %}


### PR DESCRIPTION
Adds support for file fields to our form macro for WTForms. This macro assumes that you'll have the field data display any uploaded files. Also updates the validation macro so that it can send through files (form.serialize() discards them), and adds file support encoding to the group forms.