### PR TITLE
Account for staff/attendee room groups for quick-add room groups

### DIFF
--- a/uber/models/hotel.py
+++ b/uber/models/hotel.py
@@ -263,7 +263,7 @@ class LotteryApplication(MagModel):
 
     @property
     def qualifies_for_staff_lottery(self):
-        return self.attendee.badge_type == c.STAFF_BADGE
+        return self.attendee.staff_hotel_lottery_eligible
     
     @property
     def current_lottery_deadline(self):

--- a/uber/templates/confirm_tabs.html
+++ b/uber/templates/confirm_tabs.html
@@ -73,7 +73,7 @@
   </a>
 </li>
 {% endif %}
-{% if not c.ACCOUNTS_ENABLED %}
+{% if not c.ATTENDEE_ACCOUNTS_ENABLED %}
 <li class="nav-item ms-auto">
   <div class="input-group me-2">
     {% if c.ART_SHOW_ENABLED and c.ART_SHOW_OPEN and not attendee.art_show_applications %}

--- a/uber/templates/hotel_lottery/room_group.html
+++ b/uber/templates/hotel_lottery/room_group.html
@@ -162,20 +162,22 @@
                     {% if application.attendee.managers and application.attendee.managers[0].hotel_eligible_attendees|length > 1 %}
                     <p>
                         <strong>Other badges on your account are NOT automatically part of your room group.</strong>
-                        {% if application.group_members|length < 3 and application.attendee.managers[0].potential_room_group_members|length > 1 %}
+                        {% set potential_room_group_members = application.attendee.managers[0].get_potential_room_group_members(staff=application.is_staff_entry) %}
+                        {% if application.group_members|length < 3 and potential_room_group_members|length > 1 %}
                         Below is a list of the badges on your account that are currently eligible to join the group.
                     </p>
                     <p>
                         We require each room group member to agree to our hotel lottery policies and provide their legal name and a contact phone number for the hotel.
                         Click on one of the badges below, fill out the form, and then select "Join "{{ application.room_group_name }}" Room Group" to add that badge to your room group.
                         <div class="list-group w-25 text-nowrap text-center">
-                            {% for attendee in application.attendee.managers[0].potential_room_group_members %}
+                            {% for attendee in potential_room_group_members %}
                             <a href="terms?attendee_id={{ attendee.id }}" class="list-group-item list-group-item-action">{{ attendee.full_name }}</a>
                             {% endfor %}
                         </div>
                         <hr/>
-                        {% else %}
+                        {% elif application.group_members %}
                         Your current room group members are listed below.
+                        {% else %} You currently have no other badges on your account that can join your room group.
                         {% endif %}
                     </p>
                     {% endif %}

--- a/uber/templates/hotel_lottery/terms.html
+++ b/uber/templates/hotel_lottery/terms.html
@@ -26,12 +26,13 @@
             {% include 'hotel_lottery/contact_info_form.html' with context %}
 
             <div class="d-flex gap-2 flex-wrap">
+            {% set room_group_owners = attendee.managers[0].get_room_group_owners(staff=attendee.staff_hotel_lottery_eligible) %}
             {% if attendee.managers and application.status in [c.PARTIAL, c.WITHDRAWN] %}
-                {% for group_leader in attendee.managers[0].room_group_owners %}
+                {% for group_leader in room_group_owners %}
                 <button type="submit" name="group_id" value="{{ group_leader.lottery_application.id }}" class="btn btn-primary">Join "{{ group_leader.lottery_application.room_group_name }}" Room Group</button>
                 {% endfor %}
             {% endif %}
-            {% if attendee.managers and application.status in [c.PARTIAL, c.WITHDRAWN] and attendee.managers[0].room_group_owners %}
+            {% if attendee.managers and application.status in [c.PARTIAL, c.WITHDRAWN] and room_group_owners %}
             <button type="submit" name="room" value="true" class="btn btn-secondary">Enter Room Lottery</button>
             <button type="submit" name="suite" value="true" class="btn btn-success">Enter Suite Lottery</button>
             <button type="submit" name="group" value="true" class="btn btn-outline-primary">Search Room Groups</button>


### PR DESCRIPTION
The quick-add function didn't account for the fact that attendees can't enter staff blocks. This should hopefully not be a problem in practice, but the rest of the code accounts for this case so we might as well also do it here.