### PR TITLE
Update purchaser logic

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -792,7 +792,8 @@ class Root:
                 session.add_attendee_to_account(attendee, account)
             else:
                 session.add(attendee)
-            receipt, receipt_items = ReceiptManager.create_new_receipt(attendee, who='non-admin', create_model=True)
+            receipt, receipt_items = ReceiptManager.create_new_receipt(attendee, who='non-admin', create_model=True,
+                                                                       purchaser_id=cart.purchaser.id)
             session.add(receipt)
             session.add_all(receipt_items)
             total_cost = sum([(item.amount * item.count) for item in receipt_items])
@@ -817,7 +818,8 @@ class Root:
         if cart.total_cost <= 0:
             used_codes = defaultdict(int)
             for attendee in cart.attendees:
-                receipt, receipt_items = ReceiptManager.create_new_receipt(attendee, who='non-admin', create_model=True)
+                receipt, receipt_items = ReceiptManager.create_new_receipt(attendee, who='non-admin', create_model=True,
+                                                                           purchaser_id=cart.purchaser.id)
                 session.add(receipt)
                 session.add_all(receipt_items)
 
@@ -897,7 +899,8 @@ class Root:
                 for model in cart.models:
                     charge_receipt, charge_receipt_items = ReceiptManager.create_new_receipt(model,
                                                                                              who='non-admin',
-                                                                                             create_model=True)
+                                                                                             create_model=True,
+                                                                                             purchaser_id=cart.purchaser.id)
                     existing_receipt = session.refresh_receipt_and_model(model, is_prereg=True)
                     if existing_receipt:
                         # Multiple attendees can have the same transaction during pre-reg,

--- a/uber/site_sections/reg_admin.py
+++ b/uber/site_sections/reg_admin.py
@@ -294,7 +294,7 @@ class Root:
             'art_show_app': model if isinstance(model, ArtShowApplication) else None,
             'group_leader_receipt_id': group_leader_receipt.id if group_leader_receipt else None,
             'group_processing_fee': group_processing_fee,
-            'receipt': receipt,
+            'active_receipt': receipt,
             'other_receipts': other_receipts,
             'closed_receipts': session.query(ModelReceipt).filter(ModelReceipt.owner_id == id,
                                                                   ModelReceipt.owner_model == model.__class__.__name__,
@@ -855,6 +855,57 @@ class Root:
                                getattr(model, 'full_name', None) or model.name, format_currency(refund_total / 100),
                                message_end
                                ))
+
+    @not_site_mappable
+    def close_receipt(self, session, id='', **params):
+        receipt = session.model_receipt(id)
+        receipt.closed = datetime.now()
+        raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                           receipt.owner_id, "Active receipt closed.")
+
+    @not_site_mappable
+    def move_to_active_receipt(self, session, id='', **params):
+        try:
+            item = session.receipt_item(id)
+        except NoResultFound:
+            item = session.receipt_transaction(id)
+        
+        model = session.get_model_by_receipt(item.receipt)
+        if not model.active_receipt:
+            raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                           model.id, "No active receipt found.")
+        item.receipt = model.active_receipt
+        item_name = "Receipt item" if isinstance(item, ReceiptItem) else "Transaction"
+        raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                           model.id, f"{item_name} successfully moved to active receipt.")
+    
+    def transfer_receipt(self, session, id, from_id):
+        try:
+            model = session.attendee(id)
+        except NoResultFound:
+            try:
+                model = session.group(id)
+            except NoResultFound:
+                model = session.art_show_application(id)
+
+        if model.active_receipt:
+            raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                               model.id, f"This registration/application already has an existing active receipt.")
+        
+        from_model = session.query(model.__class__).filter_by(id=from_id).first()
+        if from_model:
+            receipt = from_model.active_receipt
+        else:
+            receipt = session.query(ModelReceipt).filter(ModelReceipt.id == from_id).first()
+
+        if not receipt:
+            raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                               model.id, f"No valid active receipt found for id {from_id}.")
+        
+        receipt.owner_id = model.id
+        raise HTTPRedirect('../reg_admin/receipt_items?id={}&message={}',
+                               model.id, f"Receipt transferred!")
+        
 
     @ajax
     def refresh_model_receipt(self, session, id=''):

--- a/uber/tasks/registration.py
+++ b/uber/tasks/registration.py
@@ -511,6 +511,7 @@ def reassign_purchaser_ids():
                                    ).filter(Group.is_valid == True).group_by(ReceiptItem.purchaser_id).all()
         purchaser_id_list = [r for r, in purchaser_ids] + [r for r, in group_purchaser_ids]
         invalid_attendees = session.query(Attendee).filter(Attendee.is_valid == False, Attendee.id.in_(purchaser_id_list))
+
         for attendee in invalid_attendees:
             alt_id = None
             valid_dupe = session.query(Attendee).filter(Attendee.is_valid == True,
@@ -519,9 +520,7 @@ def reassign_purchaser_ids():
                                                         Attendee.email == attendee.email).first()
             if valid_dupe:
                 alt_id = valid_dupe.id
-            elif c.ATTENDEE_ACCOUNTS_ENABLED:
-                alt_id = attendee.managers[0].fallback_purchaser_id
-            elif attendee.badge_pickup_group:
+            elif not c.ATTENDEE_ACCOUNTS_ENABLED and attendee.badge_pickup_group:
                 alt_id = attendee.badge_pickup_group.fallback_purchaser_id
 
             if alt_id:

--- a/uber/templates/reg_admin/receipt_items.html
+++ b/uber/templates/reg_admin/receipt_items.html
@@ -394,6 +394,51 @@
     });
   };
 
+  var closeReceipt = function (receiptId) {
+    bootbox.confirm({
+      title: "Close Active Receipt?",
+      message: "This will not affect this {{ model_str }}'s registration or refund any money, but all receipt items will be considered invalid " +
+               "and no longer counted in budget reports. This should only be done for unpaid receipts or when merging receipts. Are you sure?",
+      buttons: {
+          confirm: {
+              label: 'Close Receipt',
+              className: 'btn-danger'
+          },
+          cancel: {
+              label: 'Nevermind',
+              className: 'btn-outline-secondary'
+          }
+      },
+      callback: function (result) {
+        if(result) {
+          window.location = 'close_receipt?id=' + receiptId
+        }
+      }
+    });
+  };
+
+  var moveTxnOrItem = function(itemOrTxnId, itemText) {bootbox.confirm({
+      title: "Move to Active Receipt?",
+      message: "This will move this " + itemText.toLowerCase() + "to the currently-active receipt. " +
+               "Are you sure?",
+      buttons: {
+          confirm: {
+              label: 'Move ' + itemText + ' To Active Receipt',
+              className: 'btn-success'
+          },
+          cancel: {
+              label: 'Nevermind',
+              className: 'btn-outline-secondary'
+          }
+      },
+      callback: function (result) {
+        if(result) {
+          window.location = 'move_to_active_receipt?id=' + itemOrTxnId
+        }
+      }
+    });
+  };
+
   var settleUp = function(txnId, refundAmt) {
     bootbox.confirm({
       title: "Refund " + refundAmt + "?",
@@ -570,8 +615,8 @@
               </div>
             </div>
           </div>
-          <div class="row g-sm-3">
-            <div class="col-12 col-sm-6"><button class="btn btn-primary">Update</button></div>
+          <div class="d-flex gap-2">
+            <button class="btn btn-primary">Update</button>
           </div>
         </form>
       </div>
@@ -906,6 +951,9 @@
           <button type="button" data-bs-toggle="modal" data-bs-target="#receiptModal-{{ item.id }}" class="btn btn-sm btn-warning">View/Edit</button>
           {{ receipt_item_macro(item, receipt) }}
           {% endif %}
+          {% if item.receipt.closed and active_receipt %}
+            <button type="button" class="btn btn-success btn-sm" onClick="moveTxnOrItem('{{ item.id }}', '{{ "Transaction" if item.method else "Receipt Item" }}')">Move to Active Receipt</button>
+          {% endif %}
         </td>
         <td>{{ item.desc }}{{ " (" ~ processors[item.method] ~ " ID: " ~ item.stripe_id ~ ")" if item.stripe_id else "" }}</td>
         <td>
@@ -1026,20 +1074,37 @@
     {% if loop.last %}</p>{% else %} | {% endif %}
     {% endfor %}
   {% endif %}
-{% if receipt %}
-  {{ receipt_table(receipt, receipt.all_sorted_items_and_txns) }}
-  <button class="btn btn-danger" onClick="fullRefund('{{ receipt.id }}')">Refund and Cancel This {{ model_str|title }}</button>
-  {% if not c.AUTHORIZENET_LOGIN_ID %}
-  OR
-  <button class="btn btn-danger" onClick="mostlyFullRefund('{{ receipt.id }}', '{{ (receipt.remaining_processing_fees / 100)|format_currency }}', '{{ (group_processing_fee / 100)|format_currency if group_leader_receipt_id else '' }}')">Refund and Cancel This {{ model_str|title }} Excluding Processing Fees</button>
+{% if active_receipt %}
+  {{ receipt_table(active_receipt, active_receipt.all_sorted_items_and_txns) }}
+  {% if attendee or group %}
+  <button class="btn btn-danger" onClick="fullRefund('{{ active_receipt.id }}')">Refund and Cancel This {{ model_str|title }}</button>
+    {% if not c.AUTHORIZENET_LOGIN_ID %}
+    OR
+    <button class="btn btn-danger" onClick="mostlyFullRefund('{{ active_receipt.id }}', '{{ (active_receipt.remaining_processing_fees / 100)|format_currency }}', '{{ (group_processing_fee / 100)|format_currency if group_leader_receipt_id else '' }}')">Refund and Cancel This {{ model_str|title }} Excluding Processing Fees</button>
+    {% endif %}
   {% endif %}
+  <button class="btn btn-outline-danger" onClick="closeReceipt('{{ active_receipt.id }}')">Close Receipt</button>
 {% else %}
   There are no active receipts for this {{ model_str }}.
-  <br/><a href="create_receipt?id={{ model.id }}" class="btn btn-success">Create Default Receipt</a> <a href="create_receipt?id={{ model.id }}&blank=true" class="btn btn-info">Create Blank Receipt</a>
-  {% if group_leader_receipt_id and attendee and attendee.badge_status != c.REFUNDED_STATUS %}
-  <button class="btn btn-danger" onClick="fullRefund('{{ group_leader_receipt_id }}')">Refund Badge Cost To Group Leader</button>
-  <button class="btn btn-danger" onClick="mostlyFullRefund('{{ group_leader_receipt_id }}', '{{ (group_processing_fee / 100)|format_currency }}')">Refund Badge Cost To Group Leader Excluding Processing Fees</a>
-  {% endif %}
+  <div class="d-flex gap-2 align-items-start">
+    <a href="create_receipt?id={{ model.id }}" class="btn btn-success">Create Default Receipt</a>
+    <a href="create_receipt?id={{ model.id }}&blank=true" class="btn btn-info">Create Blank Receipt</a>
+    <a href="#assign-receipt" class="btn btn-primary" data-bs-toggle="collapse">Assign Existing Receipt by ID</a>
+    <div id="assign-receipt" class="collapse">
+      <form method="post" action="transfer_receipt">
+      <input type="hidden" name="id" value="{{ model.id }}" />
+      <div class="input-group">
+        <input class="form-control" size="4" id="from_id" name="from_id" value="" required>
+        <button type="submit" class="btn btn-primary">Assign</button>
+      </div>
+      <div class="form-text">Enter the ID of the {{ model_str }} whose active receipt you want to reassign to this {{ model_str }}.</div>
+      </form>
+    </div>
+    {% if group_leader_receipt_id and attendee and attendee.badge_status != c.REFUNDED_STATUS %}
+    <button class="btn btn-danger" onClick="fullRefund('{{ group_leader_receipt_id }}')">Refund Badge Cost To Group Leader</button>
+    <button class="btn btn-danger" onClick="mostlyFullRefund('{{ group_leader_receipt_id }}', '{{ (group_processing_fee / 100)|format_currency }}')">Refund Badge Cost To Group Leader Excluding Processing Fees</a>
+    {% endif %}
+  </div>
 {% endif %}
 </div>
 </div>


### PR DESCRIPTION
Updates and improves the way we handle purchaser IDs:
- Fixes a bug where purchaser_id wasn't being assigned in several cases
- Removes the account-based fallback ID, as we consider it acceptable to have invalid purchasers
- Adds controls to allow transferring and merging receipts (the latter being doable by closing an existing receipt, transferring an active receipt, and then moving all the items from the closed receipt to the transferred receipt)