### PR TITLE
Add logic for under 17 badges and accounts

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -1750,6 +1750,7 @@ c.TERMINAL_ID_TABLE = {k.lower().replace('-', ''): v for k, v in _config['secret
 
 c.SHIFTLESS_DEPTS = {getattr(c, dept.upper()) for dept in c.SHIFTLESS_DEPTS}
 c.PREASSIGNED_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c.PREASSIGNED_BADGE_TYPES]
+c.DEFAULT_COMPED_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c.DEFAULT_COMPED_BADGE_TYPES]
 c.TRANSFERABLE_BADGE_TYPES = [getattr(c, badge_type.upper()) for badge_type in c.TRANSFERABLE_BADGE_TYPES]
 
 c.MIVS_CHECKLIST = _config['mivs_checklist']

--- a/uber/config.py
+++ b/uber/config.py
@@ -576,6 +576,73 @@ class Config(_Overridable):
             for badge_type, desc in self.AT_THE_DOOR_BADGE_OPTS
             if self.BADGES[badge_type] in c.DAYS_OF_WEEK
         }
+    
+    @request_cached_property
+    @dynamic
+    def FORMATTED_ATTENDANCE_TYPES(self):
+        attendance_types = [{
+            'name': c.ATTENDANCE_TYPES[c.WEEKEND],
+            'desc': "Allows access to the convention for its duration.",
+            'value': c.WEEKEND,
+        }]
+        if hasattr(self, 'SINGLE_DAY') and c.SINGLE_DAY in c.ATTENDANCE_TYPES:
+            attendance_types.append({
+            'name': c.ATTENDANCE_TYPES[c.SINGLE_DAY],
+            'desc': "Allows access to the convention for one day.",
+            'value': c.SINGLE_DAY,
+            })
+        return attendance_types
+    
+    @request_cached_property
+    @dynamic
+    def SOLD_OUT_BADGES_SINGLE(self):
+        opts = []
+
+        if not self.FRIDAY_AVAILABLE:
+            opts.append(self.FRIDAY)
+        if not self.SATURDAY_AVAILABLE:
+            opts.append(self.SATURDAY)
+        if not self.SUNDAY_AVAILABLE:
+            opts.append(self.SUNDAY)
+
+        return opts
+
+    def single_day_opt(self, day_name):
+        price = self.BADGE_PRICES['single_day'].get(day_name) or self.DEFAULT_SINGLE_DAY
+        badge = getattr(self, day_name.upper())
+        if getattr(self, day_name.upper() + '_AVAILABLE', None):
+            return {
+                        'name': day_name,
+                        'desc': "Can be upgraded to an Attendee badge later.",
+                        'value': badge,
+                        'price': price,
+                    }
+        
+    @request_cached_property
+    @dynamic
+    def FORMATTED_SINGLE_BADGES(self):
+        badge_types = []
+        if self.ONE_DAYS_ENABLED:
+            if self.PRESELL_ONE_DAYS and c.BEFORE_PREREG_TAKEDOWN:
+                for day_name in ["Friday", "Saturday", "Sunday"]:
+                    new_opt = self.single_day_opt(day_name)
+                    badge_types += [new_opt] if new_opt is not None else []
+            elif self.PRESELL_ONE_DAYS and localized_now().date() >= self.EPOCH.date():
+                after_today = False
+                today_name = localized_now().strftime('%A')
+                for day_name in ["Friday", "Saturday", "Sunday"]:
+                    if after_today or day_name == today_name:
+                        new_opt = self.single_day_opt(day_name)
+                        badge_types += [new_opt] if new_opt is not None else []
+                        after_today = True
+            elif self.ONE_DAY_BADGE_AVAILABLE:
+                badge_types.append({
+                    'name': 'Single Day',
+                    'desc': "Can be upgraded to an Attendee badge later.",
+                    'value': c.ONE_DAY_BADGE,
+                    'price': self.DEFAULT_SINGLE_DAY
+                })
+        return badge_types
 
     @property
     def FORMATTED_BADGE_TYPES(self):

--- a/uber/configspec.ini
+++ b/uber/configspec.ini
@@ -413,6 +413,11 @@ jira_collector_urls = string_list(default=list())
 # groups defined below.
 collect_exact_birthdate = boolean(default=True)
 
+# Set this to set a maximum age an attendee can be on an account by themselves.
+# Otherwise we throw an error message during preregistration.
+# Requires attendee_accounts_enabled since that's the only way we can "remember" who else has registered
+accompanying_adult_age = integer(default=13)
+
 # Certain events need attendees' full addresses - others will only want some
 # information. If this is turned off, attendees are only asked for their zipcode,
 # emergency contact number, and cellphone number.
@@ -1507,6 +1512,10 @@ __many__ = string
 # their description value to the empty string.  You should only do this if
 # you're really sure that you know what you're doing, since removing options
 # which the core system relies upon could cause all kinds of problems.
+
+# To allow selling single-day badges during prereg, add a "single_day" option here
+[[attendance_type]]
+weekend = string(default="Full Weekend Badge")
 
 [[badge]]
 attendee_badge  = string(default="Attendee")

--- a/uber/forms/attendee.py
+++ b/uber/forms/attendee.py
@@ -67,7 +67,9 @@ class PersonalInfo(AddressForm):
 class BadgeExtras(MagForm):
     dynamic_choices_fields = {'shirt': lambda: c.SHIRT_OPTS, 'staff_shirt': lambda: c.STAFF_SHIRT_OPTS}
 
+    attendance_type = HiddenIntField('Single Day or Weekend Badge?')
     badge_type = HiddenIntField('Badge Type')
+    badge_type_single = HiddenIntField('Badge Type', default=c.ATTENDEE_BADGE)
     amount_extra = HiddenIntField('Pre-order Merch')
     extra_donation = IntegerField('Extra Donation', widget=NumberInputGroup(),
                                   description=popup_link("../static_views/givingExtra.html", "Learn more"))

--- a/uber/models/attendee.py
+++ b/uber/models/attendee.py
@@ -932,11 +932,24 @@ class Attendee(MagModel, TakesPaymentMixin):
 
     @property
     def attendance_type(self):
-        return c.SINGLE_DAY if self.badge_type in [c.ONE_DAY_BADGE, c.FRIDAY, c.SATURDAY, c.SUNDAY] else c.WEEKEND
+        return c.SINGLE_DAY if self.badge_type == c.ONE_DAY_BADGE or self.is_presold_oneday else c.WEEKEND
 
     @property
-    def available_attendance_types(self):
-        return c.FORMATTED_ATTENDANCE_TYPES
+    def available_attendance_type_opts(self):
+        if self.is_new or self.is_unpaid:
+            return c.FORMATTED_ATTENDANCE_TYPES
+        attendance_types = [{
+            'name': c.ATTENDANCE_TYPES[c.WEEKEND],
+            'desc': "Allows access to the convention for its duration.",
+            'value': c.WEEKEND,
+        }]
+        if self.attendance_type == c.SINGLE_DAY:
+            attendance_types.append({
+            'name': c.ATTENDANCE_TYPES[c.SINGLE_DAY],
+            'desc': "Allows access to the convention for one day.",
+            'value': c.SINGLE_DAY,
+            })
+        return attendance_types
 
     @property
     def available_single_badge_opts(self):

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -274,7 +274,16 @@ def one_day_or_upgraded_badge_cost(attendee):
 
 @receipt_calculation.Attendee
 def badge_upgrade_cost(attendee, new_attendee=None):
-    if not new_attendee:
+    if not new_attendee and attendee.badge_type in c.BADGE_TYPE_PRICES:
+        new_cost = c.BADGE_TYPE_PRICES[attendee.badge_type] * 100
+        old_cost = cost_from_base_badge_item(attendee, new_attendee)
+        if old_cost == 0:
+            if skip_badge_cost_calc(attendee, new_receipt=True):
+                old_cost = attendee.calculate_badge_price(include_price_override=False) * 100
+            else:
+                return
+        return (f"Upgrade to {attendee.badge_type_label} Badge", new_cost - old_cost, 'badge_type')
+    elif not new_attendee:
         return
 
     if not needs_badge_change_calc(attendee) and not needs_badge_change_calc(new_attendee):

--- a/uber/receipt_items.py
+++ b/uber/receipt_items.py
@@ -194,7 +194,7 @@ def base_badge_cost(attendee, new_attendee=None):
     Special logic for new receipts only:
     - Skip entirely if this attendee is buying a promo code group, as that is its own item
     - If the badge is upgraded, log the attendee badge type/price, as the upgrade is its own item
-    - All badges in c.DEFAULT_COMPED_BADGE_TYPES check for "need not pay" to see if the badge is free,
+    - All badges in c.DEFAULT_COMPED_BADGE_TYPES are free if they're prereg badges or marked NEED_NOT_PAY,
         otherwise we log their normal cost and add the comp as a separate line-item in another function
     - Finally, if a badge is 'paid by group' it is also logged as a free item
     """
@@ -214,7 +214,8 @@ def base_badge_cost(attendee, new_attendee=None):
     else:
         label = f"{attendee.badge_type_label} Badge for {attendee.full_name}"
 
-    if orig_badge_type not in c.DEFAULT_COMPED_BADGE_TYPES and attendee.paid == c.NEED_NOT_PAY:
+    if orig_badge_type in c.DEFAULT_COMPED_BADGE_TYPES and (attendee.paid == c.NEED_NOT_PAY or
+                                                            attendee.creator is None):
         cost = 0
     if attendee.paid == c.PAID_BY_GROUP:
         cost = 0

--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -69,30 +69,6 @@ def _add_promo_code(session, attendee, submitted_promo_code):
         session.add_promo_code_to_attendee(attendee, submitted_promo_code)
 
 
-def check_prereg_promo_code(session, attendee, codes_in_cart=defaultdict(int)):
-    """
-    Prevents double-use of promo codes if two people have the same promo code in their cart but only one use is
-    remaining. If the attendee originally entered a 'universal' group code, which we track via
-    PreregCart.universal_promo_codes, we instead try to find a different valid code and only throw an error if
-    there are none left.
-    """
-    promo_code = session.query(PromoCode).filter(PromoCode.id == attendee.promo_code_id).with_for_update().one()
-
-    if not promo_code.is_unlimited and (not promo_code.uses_remaining or
-                                        promo_code.uses_remaining - codes_in_cart[promo_code.code] <= 0):
-        universal_code = PreregCart.universal_promo_codes.get(attendee.id)
-        if universal_code:
-            message = session.add_promo_code_to_attendee(attendee, universal_code, codes_in_cart)
-            session.commit()
-            if message:
-                return f"There are no more badges left in the group {attendee.full_name} " \
-                    f"is trying to claim a badge in."
-            return ""
-        attendee.promo_code_id = None
-        session.commit()
-        return "The promo code you're using for {} has been used already.".format(attendee.full_name)
-
-
 def update_prereg_cart(session):
     pending_preregs = PreregCart.pending_preregs.copy()
     for id in pending_preregs:
@@ -743,7 +719,6 @@ class Root:
 
     def at_door_confirmation(self, session, message='', qr_code_id='', **params):
         cart = PreregCart(listify(PreregCart.unpaid_preregs.values()))
-        used_codes = defaultdict(int)
         registrations_list = []
         account = session.current_attendee_account() if c.ATTENDEE_ACCOUNTS_ENABLED else None
         account_pickup_group = session.query(BadgePickupGroup).filter_by(account_id=account.id).first() if account else None
@@ -777,6 +752,10 @@ class Root:
             if pickup_group:
                 qr_code_id = pickup_group.public_id
 
+        prereg_cart_error = cart.prereg_cart_checks(session)
+        if prereg_cart_error:
+            raise HTTPRedirect('index?message={}', prereg_cart_error)
+
         for attendee in cart.attendees:
             registrations_list.append(attendee.full_name)
             if c.ATTENDEE_ACCOUNTS_ENABLED:
@@ -793,15 +772,7 @@ class Root:
                 session.add(old_attendee)
                 del cherrypy.session['imported_attendee_ids'][attendee.id]
 
-            if attendee.promo_code_code:
-                message = check_prereg_promo_code(session, attendee, used_codes)
-                if not message:
-                    used_codes[attendee.promo_code_code] += 1
-
-            if message:
-                session.rollback()
-                raise HTTPRedirect('index?message={}', message)
-            elif account:
+            if account:
                 session.add_attendee_to_account(attendee, account)
             else:
                 session.add(attendee)
@@ -829,7 +800,10 @@ class Root:
         cart = PreregCart(listify(PreregCart.unpaid_preregs.values()))
         cart.set_total_cost()
         if cart.total_cost <= 0:
-            used_codes = defaultdict(int)
+            prereg_cart_error = cart.prereg_cart_checks(session)
+            if prereg_cart_error:
+                raise HTTPRedirect('index?message={}', prereg_cart_error)
+            
             for attendee in cart.attendees:
                 receipt, receipt_items = ReceiptManager.create_new_receipt(attendee, who='non-admin', create_model=True,
                                                                            purchaser_id=cart.purchaser.id)
@@ -846,15 +820,7 @@ class Root:
                     session.add(old_attendee)
                     del cherrypy.session['imported_attendee_ids'][attendee.id]
 
-                if attendee.promo_code_code:
-                    message = check_prereg_promo_code(session, attendee, used_codes)
-                    if not message:
-                        used_codes[attendee.promo_code_code] += 1
-
-                if message:
-                    session.rollback()
-                    raise HTTPRedirect('index?message={}', message)
-                elif c.ATTENDEE_ACCOUNTS_ENABLED:
+                if c.ATTENDEE_ACCOUNTS_ENABLED:
                     session.add_attendee_to_account(attendee, session.current_attendee_account())
                 else:
                     session.add(attendee)
@@ -883,80 +849,72 @@ class Root:
                 HTTPRedirect('form?message={}', 'Your preregistration has already been finalized')
             message = 'Your total cost was $0. Your credit card has not been charged.'
         else:
-            used_codes = defaultdict(int)
+            prereg_cart_error = cart.prereg_cart_checks(session)
+            if prereg_cart_error:
+                return {'error': prereg_cart_error}
+            
             for attendee in cart.attendees:
-                if not message and attendee.promo_code_code:
-                    message = check_prereg_promo_code(session, attendee, used_codes)
-                if not message:
-                    used_codes[attendee.promo_code_code] += 1
-                    form_list = ['PersonalInfo', 'BadgeExtras', 'PreregOtherInfo', 'Consents']
-                    # Populate checkboxes based on the model (I need a better solution for this)
-                    params = {}
-                    if not attendee.legal_name:
-                        params['same_legal_name'] = True
-                    params['pii_consent'] = True
+                form_list = ['BadgeExtras'] # Re-check purchase limits
+                forms = load_forms({}, attendee, form_list, checkboxes_present=False)
 
-                    forms = load_forms(params, attendee, form_list, checkboxes_present=False)
-
-                    all_errors = validate_model(forms, attendee)
-                    if all_errors:
-                        pass
-                        # Flatten the errors as we don't have fields on this page
-                        # message = ' '.join([item for sublist in all_errors.values() for item in sublist])
+                all_errors = validate_model(forms, attendee)
+                if all_errors:
+                    message = ' '.join([item for sublist in all_errors.values() for item in sublist])
                 if message:
                     message += f" Please click 'Edit' next to {attendee.full_name}'s registration to fix any issues."
                     break
+            
+            if message:
+                return {'error': message}
 
-            if not message:
-                receipts = []
-                for model in cart.models:
-                    charge_receipt, charge_receipt_items = ReceiptManager.create_new_receipt(model,
-                                                                                             who='non-admin',
-                                                                                             create_model=True,
-                                                                                             purchaser_id=cart.purchaser.id)
-                    existing_receipt = session.refresh_receipt_and_model(model, is_prereg=True)
-                    if existing_receipt:
-                        # Multiple attendees can have the same transaction during pre-reg,
-                        # so we always cancel any incomplete transactions
-                        incomplete_txn = existing_receipt.get_last_incomplete_txn()
-                        if incomplete_txn:
-                            incomplete_txn.cancelled = datetime.now()
-                            session.add(incomplete_txn)
+            receipts = []
+            for model in cart.models:
+                charge_receipt, charge_receipt_items = ReceiptManager.create_new_receipt(model,
+                                                                                            who='non-admin',
+                                                                                            create_model=True,
+                                                                                            purchaser_id=cart.purchaser.id)
+                existing_receipt = session.refresh_receipt_and_model(model, is_prereg=True)
+                if existing_receipt:
+                    # Multiple attendees can have the same transaction during pre-reg,
+                    # so we always cancel any incomplete transactions
+                    incomplete_txn = existing_receipt.get_last_incomplete_txn()
+                    if incomplete_txn:
+                        incomplete_txn.cancelled = datetime.now()
+                        session.add(incomplete_txn)
 
-                        # If their registration costs changed, close their old receipt
-                        compare_fields = ['amount', 'count', 'desc']
-                        existing_items = [item.to_dict(compare_fields) for item in existing_receipt.receipt_items]
-                        new_items = [item.to_dict(compare_fields) for item in charge_receipt_items]
+                    # If their registration costs changed, close their old receipt
+                    compare_fields = ['amount', 'count', 'desc']
+                    existing_items = [item.to_dict(compare_fields) for item in existing_receipt.receipt_items]
+                    new_items = [item.to_dict(compare_fields) for item in charge_receipt_items]
 
-                        for item in existing_items:
-                            del item['id']
-                        for item in new_items:
-                            del item['id']
+                    for item in existing_items:
+                        del item['id']
+                    for item in new_items:
+                        del item['id']
 
-                        diff_list = [x for x in existing_items + new_items
-                                     if x not in existing_items or x not in new_items]
+                    diff_list = [x for x in existing_items + new_items
+                                    if x not in existing_items or x not in new_items]
 
-                        if diff_list:
-                            existing_receipt.closed = datetime.now()
-                            session.add(existing_receipt)
-                        else:
-                            receipts.append(existing_receipt)
+                    if diff_list:
+                        existing_receipt.closed = datetime.now()
+                        session.add(existing_receipt)
+                    else:
+                        receipts.append(existing_receipt)
 
-                    if not existing_receipt or existing_receipt.closed:
-                        session.add(charge_receipt)
-                        for item in charge_receipt_items:
-                            session.add(item)
-                        session.commit()
-                        receipts.append(charge_receipt)
+                if not existing_receipt or existing_receipt.closed:
+                    session.add(charge_receipt)
+                    for item in charge_receipt_items:
+                        session.add(item)
+                    session.commit()
+                    receipts.append(charge_receipt)
 
-                if not message:
-                    receipt_email = session.current_attendee_account().email \
-                        if c.ATTENDEE_ACCOUNTS_ENABLED else cart.receipt_email
-                    charge = TransactionRequest(receipt_email=receipt_email,
-                                                description=cart.description,
-                                                amount=sum([receipt.current_amount_owed for receipt in receipts]),
-                                                who='non-admin')
-                    message = charge.create_payment_intent()
+            receipt_email = session.current_attendee_account().email \
+                if c.ATTENDEE_ACCOUNTS_ENABLED else cart.receipt_email
+            charge = TransactionRequest(receipt_email=receipt_email,
+                                        description=cart.description,
+                                        amount=sum([receipt.current_amount_owed for receipt in receipts]),
+                                        who='non-admin')
+            message = charge.create_payment_intent()
 
         if message:
             return {'error': message}

--- a/uber/templates/forms/attendee/badge_extras.html
+++ b/uber/templates/forms/attendee/badge_extras.html
@@ -35,6 +35,37 @@ get shirtSize() { return (this.getsFreeEventShirt() && !this.eventShirtOptOut())
 
 <div class="row g-sm-3 mb-3">
 {% block badge_type %}
+{{ badge_extras.attendance_type(id=id_upgrade_prepend ~ "attendance_type") }}
+
+{% if c.PRESELL_ONE_DAYS and c.FORMATTED_ATTENDANCE_TYPES|length > 1 and (not receipt or upgrade_modal and attendee.attendance_type == c.SINGLE_DAY) %}
+    {{ form_macros.card_select(badge_extras.attendance_type,
+                               c.FORMATTED_ATTENDANCE_TYPES,
+                               target_field_id=id_upgrade_prepend ~ "attendance_type") }}
+    </div>
+    <div id="one-day-alert" class="row">
+        <div class="col"><div class="alert alert-info mb-0"><em>Please select which day you would like to attend.</em></div></div>
+    </div>
+    <div class="row g-sm-3 mb-3">
+        <input type="hidden" id="badge_type_single" /> {# Dummy attribute to make validation message hideable #}
+        {{ form_macros.card_select(badge_extras.badge_type_single,
+                                    attendee.available_single_badge_opts, disabled_opts=c.SOLD_OUT_BADGES_SINGLE[1:] if attendee.badge_type in c.SOLD_OUT_BADGES_SINGLE else c.SOLD_OUT_BADGES_SINGLE,
+                                    target_field_id=id_upgrade_prepend ~ "badge_type") }}
+    </div>
+    <script type="text/javascript">
+        var switchBadgeTypeOpts = function() {
+            let attendanceType = $('#{{ id_upgrade_prepend }}attendance_type').val();
+            setVisible($('#badge_type_single-select').parents('.row'), attendanceType == '{{ c.SINGLE_DAY }}');
+            setVisible($('#one-day-alert'), attendanceType == '{{ c.SINGLE_DAY }}');
+            setVisible($('#badge_type-select').parents('.row'), attendanceType == '{{ c.WEEKEND }}');
+        }
+        $(function () {
+            switchBadgeTypeOpts();
+            $('#{{ id_upgrade_prepend }}attendance_type').on('change', switchBadgeTypeOpts);
+        })
+    </script>
+    <div class="row g-sm-3 mb-3">
+{% endif %}
+
 {{ badge_extras.badge_type(id=id_upgrade_prepend ~ "badge_type", **{'x-model.number': "badge_type"}) }}
 
 {% if c.BADGE_TYPE_PRICES and (not receipt or upgrade_modal) %}

--- a/uber/templates/forms/attendee/badge_extras.html
+++ b/uber/templates/forms/attendee/badge_extras.html
@@ -39,7 +39,7 @@ get shirtSize() { return (this.getsFreeEventShirt() && !this.eventShirtOptOut())
 
 {% if c.PRESELL_ONE_DAYS and c.FORMATTED_ATTENDANCE_TYPES|length > 1 and (not receipt or upgrade_modal and attendee.attendance_type == c.SINGLE_DAY) %}
     {{ form_macros.card_select(badge_extras.attendance_type,
-                               c.FORMATTED_ATTENDANCE_TYPES,
+                               attendee.available_attendance_type_opts,
                                target_field_id=id_upgrade_prepend ~ "attendance_type") }}
     </div>
     <div id="one-day-alert" class="row">

--- a/uber/templates/preregistration/attendee_card.html
+++ b/uber/templates/preregistration/attendee_card.html
@@ -113,7 +113,6 @@
                 Add to Cart &nbsp;<i class="fa fa-plus"></i>
             </a>
         </div>
-
     {% endif %}
 </div>
 <div class="d-flex mt-2"><span class="form-text ms-auto"><em>Confirmation # {{ attendee.id }}</em></span></div>

--- a/uber/templates/preregistration/homepage.html
+++ b/uber/templates/preregistration/homepage.html
@@ -179,10 +179,12 @@
                 {% endfor %}
                 </tbody>
                 </table>
+                {% block multi_cancel_modal_text scoped %}
                 <p>
                     Pressing the "Cancel Selected Registration(s)" button will <strong>immediately and irreversibly</strong> cancel all checked registrations.
                     Any registration fees and any upgrades purchased will be refunded to the original payment method.
                 </p>
+                {% endblock %}
             </div>
             <div class="modal-footer">
                 <form id="refund-cancel" action="abandon_badges" method="post">

--- a/uber/validations/attendee.py
+++ b/uber/validations/attendee.py
@@ -213,8 +213,18 @@ def upgrade_sold_out(form, field):
 
 @BadgeExtras.field_validation('badge_type_single')
 def must_select_day(form, field):
-    if form.attendance_type.data and form.attendance_type.data == c.SINGLE_DAY and field.data not in [c.FRIDAY, c.SATURDAY, c.SUNDAY]:
+    if form.attendance_type.data and form.attendance_type.data == c.SINGLE_DAY and c.BADGES[field.data] not in c.DAYS_OF_WEEK:
         raise ValidationError("Please select which day you would like to attend.")
+
+
+@BadgeExtras.field_validation('badge_type')
+def must_select_type(form, field):
+    if not c.BADGE_TYPE_PRICES:
+        return
+
+    if form.attendance_type.data and form.attendance_type.data == c.WEEKEND and \
+            field.data != c.ATTENDEE_BADGE and field.data not in c.BADGE_TYPE_PRICES:
+        raise ValidationError("Please select what type of badge you want.")
 
 
 @BadgeExtras.new_or_changed('badge_type')

--- a/uber/validations/attendee.py
+++ b/uber/validations/attendee.py
@@ -211,6 +211,12 @@ def upgrade_sold_out(form, field):
         raise ValidationError("The upgrade you have selected is no longer available.")
 
 
+@BadgeExtras.field_validation('badge_type_single')
+def must_select_day(form, field):
+    if form.attendance_type.data and form.attendance_type.data == c.SINGLE_DAY and field.data not in [c.FRIDAY, c.SATURDAY, c.SUNDAY]:
+        raise ValidationError("Please select which day you would like to attend.")
+
+
 @BadgeExtras.new_or_changed('badge_type')
 def no_more_custom_badges(form, field):
     if field.data in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE:


### PR DESCRIPTION
Adds checks to the prereg workflow that prevent someone from registering a badge under 17 if there are no adults in their cart or on their account. Also:
- Moves the Attendance Type selection from the MFF plugin to the main plugin, enabling it based on config
- Fixes the price calculations for preregistering badge types in c.BADGE_TYPE_PRICES
- Adds a block to the multi-cancel modal, which allows plugins to override the description underneath the list of badges
- Fixes c.DEFAULT_COMPED_BADGE_TYPES to actually work and let people register free badge types for free