### PR TITLE
Restoring initialization of used_codes

### DIFF
--- a/uber/site_sections/preregistration.py
+++ b/uber/site_sections/preregistration.py
@@ -852,7 +852,8 @@ class Root:
             prereg_cart_error = cart.prereg_cart_checks(session)
             if prereg_cart_error:
                 return {'error': prereg_cart_error}
-            
+
+            used_codes = defaultdict(int)
             for attendee in cart.attendees:
                 if not message and attendee.promo_code_code:
                     message = check_prereg_promo_code(session, attendee, used_codes)


### PR DESCRIPTION
Staging is throwing this error when attempting to pay for a registration:
```
Traceback (most recent call last):
  File "/app/uber/decorators.py", line 429, in charge
    return func(self, session=session, id=id, **kwargs)
  File "/app/uber/site_sections/preregistration.py", line 860, in prereg_payment
    used_codes[attendee.promo_code_code] += 1
    ^^^^^^^^^^
NameError: name 'used_codes' is not defined
```

This restores the initialization of `used_codes` removed here: https://github.com/MidwestFurryFandom/rams/commit/7ed7b48c1a934080ee7c7c89555d95d25e00bc96#diff-03575a268e0b3eb2ce5dbf03b98d2f6452807208425701051a48dfe476847b0bL832