### PR TITLE
Stop checking problem names

### DIFF
--- a/uber/tasks/redis.py
+++ b/uber/tasks/redis.py
@@ -64,6 +64,7 @@ def update_shirt_counts():
 
 @celery.schedule(timedelta(minutes=15))
 def update_problem_names():
+    return
     from uber.models import Attendee, Session
 
     posix_regex_list = []


### PR DESCRIPTION
I believe this is crashing redis in some circumstances, and we want that to not happen during prereg opening in particular.