### PR TITLE
Fix setting badge_num on attendee creation

### DIFF
--- a/uber/site_sections/registration.py
+++ b/uber/site_sections/registration.py
@@ -119,7 +119,11 @@ class Root:
             attendees = session.index_attendees().filter(*filter)
             count = attendees.count()
 
-        attendees = attendees.order(order)
+        if order in ['badge_num', '-badge_num']:
+            attendees = attendees.outerjoin(BadgeInfo).order_by(BadgeInfo.ident.desc()
+                                                                if order.startswith('-') else BadgeInfo.ident)
+        else:
+            attendees = attendees.order(order)
 
         page = int(page)
         if search_text:


### PR DESCRIPTION
The badge_num setter depends on the attendee object having a session attached to it, but when we created new attendees weren't adding them to the session until AFTER setting their badge number. We now add them to the session right away.

Also fixes ordering attendees by badge number on /registration/.