### PR TITLE
Stop deleting roommate name and cellphone

### DIFF
--- a/uber/site_sections/hotel_lottery.py
+++ b/uber/site_sections/hotel_lottery.py
@@ -36,6 +36,7 @@ def _join_room_group(session, application, group_id):
         defaults = LotteryApplication().to_dict()
         for attr in defaults:
             if attr not in ['id', 'attendee_id', 'response_id',
+                            'legal_first_name', 'legal_last_name', 'cellphone',
                             'terms_accepted', 'data_policy_accepted',
                             'entry_started', 'entry_metadata']:
                 setattr(application, attr, defaults.get(attr))


### PR DESCRIPTION
We can recover the data involved, but this is definitely a problem we want to fix ASAP.